### PR TITLE
Add semantic game events and presenter pipeline

### DIFF
--- a/MooSharp.Web/Program.cs
+++ b/MooSharp.Web/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddSingleton(channel.Reader);
 
 builder.RegisterCommandDefinitions();
 builder.RegisterCommandHandlers();
+builder.RegisterPresenters();
 
 builder.Services.AddSignalR();
 

--- a/MooSharp/Commands/Commands/ExamineCommand.cs
+++ b/MooSharp/Commands/Commands/ExamineCommand.cs
@@ -36,30 +36,20 @@ public class ExamineHandler : IHandler<ExamineCommand>
 
         if (cmd.Target is "me")
         {
-            result.Add(player, "You took a look at yourself. You're looking pretty good.");
-
-            var descriptions = player.Inventory
-                .Select(s => s.Value.Description)
+            var inventory = player.Inventory
+                .Select(s => s.Value)
                 .ToList();
 
-            if (descriptions.Any())
-            {
-                result.Add(player, "You have:");
-
-                foreach (var se in descriptions)
-                {
-                    result.Add(player, se);
-                }
-            }
+            result.Add(player, new SelfExaminedEvent(player, inventory));
         }
 
         var current = player.CurrentLocation;
 
         var obj = player.CurrentLocation.FindObject(cmd.Target);
-        
+
         if (obj is not null)
         {
-            result.Add(player, obj.Description);
+            result.Add(player, new ObjectExaminedEvent(obj));
         }
 
         return Task.FromResult(result);

--- a/MooSharp/Commands/Commands/TakeCommand.cs
+++ b/MooSharp/Commands/Commands/TakeCommand.cs
@@ -34,7 +34,7 @@ public class TakeHandler : IHandler<TakeCommand>
 
         if (o is null)
         {
-            result.Add(player, $"There is no {cmd.Target} here.");
+            result.Add(player, new ItemNotFoundEvent(cmd.Target));
 
             return Task.FromResult(result);
         }
@@ -44,14 +44,15 @@ public class TakeHandler : IHandler<TakeCommand>
             player.CurrentLocation.Contents.Remove(o);
             o.Owner = player;
             player.Inventory.Add(o.Name, o);
+            result.Add(player, new ItemTakenEvent(o));
         }
         else if (o.Owner == player)
         {
-            result.Add(player, $"You take the {o.Name}.");
+            result.Add(player, new ItemTakenEvent(o));
         }
         else
         {
-            result.Add(player, $"Someone else already has the {o.Name}!");
+            result.Add(player, new ItemOwnedByOtherEvent(o, o.Owner));
         }
 
         return Task.FromResult(result);

--- a/MooSharp/Messaging/CommandResult.cs
+++ b/MooSharp/Messaging/CommandResult.cs
@@ -1,6 +1,14 @@
 namespace MooSharp.Messaging;
 
-public record GameMessage(Player Player, string Content);
+public enum MessageAudience
+{
+    Actor,
+    Observer
+}
+
+public interface IGameEvent;
+
+public record GameMessage(Player Player, IGameEvent Event, MessageAudience Audience = MessageAudience.Actor);
 
 public class CommandResult
 {
@@ -8,25 +16,25 @@ public class CommandResult
     public List<GameMessage> Messages { get; } = new();
 
     // Helper to add a message to a specific player
-    public void Add(Player player, string content) 
+    public void Add(Player player, IGameEvent @event, MessageAudience audience = MessageAudience.Actor)
     {
-        Messages.Add(new GameMessage(player, content));
+        Messages.Add(new GameMessage(player, @event, audience));
     }
 
     // Helper to broadcast to a room (excluding specific people usually)
-    public void Broadcast(Room room, string content, params Player[] exclude)
+    public void Broadcast(Room room, IGameEvent @event, MessageAudience audience = MessageAudience.Observer, params Player[] exclude)
     {
         foreach (var player in room.PlayersInRoom)
         {
             if (!exclude.Contains(player))
             {
-                Messages.Add(new (player, content));
+                Messages.Add(new (player, @event, audience));
             }
         }
     }
 
-    public void BroadcastToAllButPlayer(Player player, string content)
+    public void BroadcastToAllButPlayer(Player player, IGameEvent @event, MessageAudience audience = MessageAudience.Observer)
     {
-        Broadcast(player.CurrentLocation, content, exclude: player);
+        Broadcast(player.CurrentLocation, @event, audience, exclude: player);
     }
 }

--- a/MooSharp/Messaging/EventFormatters.cs
+++ b/MooSharp/Messaging/EventFormatters.cs
@@ -1,0 +1,104 @@
+using System.Text;
+
+namespace MooSharp.Messaging;
+
+public class SystemMessageEventFormatter : IGameEventFormatter<SystemMessageEvent>
+{
+    public string FormatForActor(SystemMessageEvent gameEvent) => gameEvent.Message;
+
+    public string FormatForObserver(SystemMessageEvent gameEvent) => gameEvent.Message;
+}
+
+public class RoomDescriptionEventFormatter : IGameEventFormatter<RoomDescriptionEvent>
+{
+    public string FormatForActor(RoomDescriptionEvent gameEvent) => gameEvent.Description;
+
+    public string FormatForObserver(RoomDescriptionEvent gameEvent) => gameEvent.Description;
+}
+
+public class ExitNotFoundEventFormatter : IGameEventFormatter<ExitNotFoundEvent>
+{
+    public string FormatForActor(ExitNotFoundEvent gameEvent) => "That exit doesn't exist.";
+
+    public string FormatForObserver(ExitNotFoundEvent gameEvent) => "That exit doesn't exist.";
+}
+
+public class PlayerMovedEventFormatter : IGameEventFormatter<PlayerMovedEvent>
+{
+    public string FormatForActor(PlayerMovedEvent gameEvent) => $"You head to {gameEvent.Destination.Description}.";
+
+    public string FormatForObserver(PlayerMovedEvent gameEvent) =>
+        $"{gameEvent.Player.Username} moved towards {gameEvent.Destination.Description}.";
+}
+
+public class PlayerDepartedEventFormatter : IGameEventFormatter<PlayerDepartedEvent>
+{
+    public string FormatForActor(PlayerDepartedEvent gameEvent) =>
+        $"You head out through {gameEvent.ExitName}.";
+
+    public string FormatForObserver(PlayerDepartedEvent gameEvent) =>
+        $"{gameEvent.Player.Username} went to {gameEvent.ExitName}";
+}
+
+public class PlayerArrivedEventFormatter : IGameEventFormatter<PlayerArrivedEvent>
+{
+    public string FormatForActor(PlayerArrivedEvent gameEvent) =>
+        $"You arrived in {gameEvent.Destination.Description}.";
+
+    public string FormatForObserver(PlayerArrivedEvent gameEvent) =>
+        $"{gameEvent.Player.Username} arrived";
+}
+
+public class ItemNotFoundEventFormatter : IGameEventFormatter<ItemNotFoundEvent>
+{
+    public string FormatForActor(ItemNotFoundEvent gameEvent) => $"There is no {gameEvent.ItemName} here.";
+
+    public string FormatForObserver(ItemNotFoundEvent gameEvent) => FormatForActor(gameEvent);
+}
+
+public class ItemTakenEventFormatter : IGameEventFormatter<ItemTakenEvent>
+{
+    public string FormatForActor(ItemTakenEvent gameEvent) => $"You take the {gameEvent.Item.Name}.";
+
+    public string FormatForObserver(ItemTakenEvent gameEvent) => $"Someone takes the {gameEvent.Item.Name}.";
+}
+
+public class ItemOwnedByOtherEventFormatter : IGameEventFormatter<ItemOwnedByOtherEvent>
+{
+    public string FormatForActor(ItemOwnedByOtherEvent gameEvent) =>
+        $"{gameEvent.Owner.Username} already has the {gameEvent.Item.Name}!";
+
+    public string FormatForObserver(ItemOwnedByOtherEvent gameEvent) =>
+        $"{gameEvent.Owner.Username} already has the {gameEvent.Item.Name}!";
+}
+
+public class SelfExaminedEventFormatter : IGameEventFormatter<SelfExaminedEvent>
+{
+    public string FormatForActor(SelfExaminedEvent gameEvent)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("You took a look at yourself. You're looking pretty good.");
+
+        if (gameEvent.Inventory.Count > 0)
+        {
+            sb.AppendLine("You have:");
+
+            foreach (var item in gameEvent.Inventory)
+            {
+                sb.AppendLine(item.Description);
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    public string FormatForObserver(SelfExaminedEvent gameEvent) => "Someone seems to be checking themselves out.";
+}
+
+public class ObjectExaminedEventFormatter : IGameEventFormatter<ObjectExaminedEvent>
+{
+    public string FormatForActor(ObjectExaminedEvent gameEvent) => gameEvent.Item.Description;
+
+    public string FormatForObserver(ObjectExaminedEvent gameEvent) => gameEvent.Item.Description;
+}

--- a/MooSharp/Messaging/GameEvents.cs
+++ b/MooSharp/Messaging/GameEvents.cs
@@ -1,0 +1,23 @@
+namespace MooSharp.Messaging;
+
+public record SystemMessageEvent(string Message) : IGameEvent;
+
+public record RoomDescriptionEvent(string Description) : IGameEvent;
+
+public record ExitNotFoundEvent(string ExitName) : IGameEvent;
+
+public record PlayerMovedEvent(Player Player, Room Destination) : IGameEvent;
+
+public record PlayerDepartedEvent(Player Player, Room Origin, string ExitName) : IGameEvent;
+
+public record PlayerArrivedEvent(Player Player, Room Destination) : IGameEvent;
+
+public record ItemNotFoundEvent(string ItemName) : IGameEvent;
+
+public record ItemTakenEvent(Object Item) : IGameEvent;
+
+public record ItemOwnedByOtherEvent(Object Item, Player Owner) : IGameEvent;
+
+public record SelfExaminedEvent(Player Player, IReadOnlyCollection<Object> Inventory) : IGameEvent;
+
+public record ObjectExaminedEvent(Object Item) : IGameEvent;

--- a/MooSharp/Messaging/IGameEventFormatter.cs
+++ b/MooSharp/Messaging/IGameEventFormatter.cs
@@ -1,0 +1,23 @@
+namespace MooSharp.Messaging;
+
+public interface IGameEventFormatter
+{
+    bool CanFormat(IGameEvent gameEvent);
+
+    string FormatForActor(IGameEvent gameEvent);
+
+    string FormatForObserver(IGameEvent gameEvent);
+}
+
+public interface IGameEventFormatter<in TEvent> : IGameEventFormatter where TEvent : IGameEvent
+{
+    string FormatForActor(TEvent gameEvent);
+
+    string FormatForObserver(TEvent gameEvent);
+
+    bool IGameEventFormatter.CanFormat(IGameEvent gameEvent) => gameEvent is TEvent;
+
+    string IGameEventFormatter.FormatForActor(IGameEvent gameEvent) => FormatForActor((TEvent)gameEvent);
+
+    string IGameEventFormatter.FormatForObserver(IGameEvent gameEvent) => FormatForObserver((TEvent)gameEvent);
+}


### PR DESCRIPTION
## Summary
- switch command results to structured game events backed by domain objects and add formatters to keep messaging separate from handlers
- introduce a presenter that renders actor/observer views and wire it into the game engine
- register the presenter pipeline via dependency injection and update handlers to emit event types

## Testing
- dotnet build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236cdd8c288331a0de58db6bb739a5)