### PR TITLE
Persist players to JSON store

### DIFF
--- a/MooSharp.Web/GameEngine.cs
+++ b/MooSharp.Web/GameEngine.cs
@@ -44,14 +44,16 @@ public class GameEngine(
         }
     }
 
-    private Task HandleDisconnectAsync(ConnectionId connectionId)
+    private async Task HandleDisconnectAsync(ConnectionId connectionId)
     {
         if (!world.Players.TryGetValue(connectionId.Value, out var player))
         {
             logger.LogWarning("Player with connection {ConnectionId} not found during disconnect", connectionId);
 
-            return Task.CompletedTask;
+            return;
         }
+
+        await playerStore.SavePlayer(player);
 
         player.CurrentLocation.PlayersInRoom.Remove(player);
 
@@ -59,7 +61,7 @@ public class GameEngine(
 
         logger.LogInformation("Player {Player} disconnected", player.Username);
 
-        return Task.CompletedTask;
+        return;
     }
 
     private async Task ProcessWorldCommand(WorldCommand command, CancellationToken ct, Player player)

--- a/MooSharp.Web/appsettings.json
+++ b/MooSharp.Web/appsettings.json
@@ -7,7 +7,8 @@
   "AllowedHosts": "*",
   "AppOptions": {
     "EnableAgents": false,
-    "WorldDataFilepath": "world.json"
+    "WorldDataFilepath": "world.json",
+    "PlayerDataFilepath": "players.json"
   },
   "Agents": {
     "OpenAIModelId": "gpt-5.1",

--- a/MooSharp/Infrastructure/AppOptions.cs
+++ b/MooSharp/Infrastructure/AppOptions.cs
@@ -6,4 +6,7 @@ public class AppOptions
 {
     [Required]
     public required string WorldDataFilepath { get; init; }
+
+    [Required]
+    public required string PlayerDataFilepath { get; init; }
 }

--- a/MooSharp/Persistence/IPlayerStore.cs
+++ b/MooSharp/Persistence/IPlayerStore.cs
@@ -1,35 +1,135 @@
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+using MooSharp;
+
 namespace MooSharp.Persistence;
 
 public interface IPlayerStore
 {
     Task SaveNewPlayer(Player player, string password);
+    Task SavePlayer(Player player);
     Task<PlayerDto?> LoadPlayer(LoginCommand command);
 }
 
 public class JsonPlayerStore : IPlayerStore
 {
-    private readonly List<PlayerDto> _players = [new()
+    private readonly SemaphoreSlim _sync = new(1, 1);
+    private readonly string _filePath;
+    private readonly List<PlayerDto> _players;
+    private readonly JsonSerializerOptions _serializerOptions = new()
     {
-        Username = "Jane Doe",
-        Password = "hunter123"
-    }];
+        WriteIndented = true,
+        Converters = { new RoomIdJsonConverter() }
+    };
 
-    public Task SaveNewPlayer(Player player, string password)
+    public JsonPlayerStore(IOptions<AppOptions> options)
     {
-        _players.Add(new()
+        _filePath = options.Value.PlayerDataFilepath
+            ?? throw new InvalidOperationException("PlayerDataFilepath is not set.");
+
+        _players = LoadPlayersFromDisk();
+    }
+
+    public async Task SaveNewPlayer(Player player, string password)
+    {
+        var dto = new PlayerDto
         {
             Username = player.Username,
             Password = password,
             CurrentLocation = player.CurrentLocation.Id
-        });
+        };
 
-        return Task.CompletedTask;
+        await UpsertPlayerAsync(dto);
     }
 
-    public Task<PlayerDto?> LoadPlayer(LoginCommand command)
+    public async Task SavePlayer(Player player)
     {
-        var player = _players.SingleOrDefault(s => s.Username == command.Username && s.Password == command.Password);
+        await _sync.WaitAsync();
 
-        return Task.FromResult(player);
+        try
+        {
+            var existingPlayer = _players.SingleOrDefault(s => s.Username == player.Username);
+
+            if (existingPlayer is null)
+            {
+                return;
+            }
+
+            existingPlayer.CurrentLocation = player.CurrentLocation.Id;
+
+            await PersistAsync();
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    public async Task<PlayerDto?> LoadPlayer(LoginCommand command)
+    {
+        await _sync.WaitAsync();
+
+        try
+        {
+            var player = _players.SingleOrDefault(s => s.Username == command.Username && s.Password == command.Password);
+
+            return player;
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    private List<PlayerDto> LoadPlayersFromDisk()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return [];
+        }
+
+        var raw = File.ReadAllText(_filePath);
+
+        var players = JsonSerializer.Deserialize<List<PlayerDto>>(raw, _serializerOptions);
+
+        return players ?? [];
+    }
+
+    private async Task UpsertPlayerAsync(PlayerDto player)
+    {
+        await _sync.WaitAsync();
+
+        try
+        {
+            var existingPlayer = _players.SingleOrDefault(s => s.Username == player.Username);
+
+            if (existingPlayer is null)
+            {
+                _players.Add(player);
+            }
+            else
+            {
+                existingPlayer.Password = player.Password;
+                existingPlayer.CurrentLocation = player.CurrentLocation;
+            }
+
+            await PersistAsync();
+        }
+        finally
+        {
+            _sync.Release();
+        }
+    }
+
+    private async Task PersistAsync()
+    {
+        var directory = Path.GetDirectoryName(_filePath);
+
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        await File.WriteAllTextAsync(_filePath, JsonSerializer.Serialize(_players, _serializerOptions));
     }
 }


### PR DESCRIPTION
## Summary
- add file-backed JSON player store that hydrates on startup and persists updates
- introduce configurable player data filepath alongside world data settings
- persist player state on disconnect to keep in-memory and on-disk records aligned

## Testing
- dotnet test MooSharp.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923725f2fc88331ac2fa8e0df95c43d)