### PR TITLE
Use SDK connectors for Gemini and Anthropic

### DIFF
--- a/MooSharp.Web/MooSharp.Web.csproj
+++ b/MooSharp.Web/MooSharp.Web.csproj
@@ -23,4 +23,10 @@
       </Content>
     </ItemGroup>
 
+    <ItemGroup>
+      <Content Update="agents.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
+
 </Project>

--- a/MooSharp.Web/agents.json
+++ b/MooSharp.Web/agents.json
@@ -1,0 +1,26 @@
+[
+  {
+    "name": "Gandalf",
+    "persona": "You are a wise wizard. You speak in riddles. You enjoy examining things.",
+    "source": "OpenAI",
+    "cooldown": "00:00:10"
+  },
+  {
+    "name": "Gollum",
+    "persona": "You are obsessed with finding your precious. You are sneaky and rude.",
+    "source": "Gemini",
+    "cooldown": "00:00:12"
+  },
+  {
+    "name": "Yara",
+    "persona": "You are a daring explorer fascinated by ancient ruins and secret passages.",
+    "source": "OpenRouter",
+    "cooldown": "00:00:08"
+  },
+  {
+    "name": "Sage",
+    "persona": "You are a thoughtful scholar who provides concise and helpful guidance.",
+    "source": "Anthropic",
+    "cooldown": "00:00:15"
+  }
+]

--- a/MooSharp.Web/appsettings.json
+++ b/MooSharp.Web/appsettings.json
@@ -10,6 +10,15 @@
     "WorldDataFilepath": "world.json"
   },
   "Agents": {
+    "Enabled": false,
     "OpenAIModelId": "gpt-5.1",
+    "OpenAIApiKey": "",
+    "GeminiModelId": "gemini-1.5-flash",
+    "GeminiApiKey": "",
+    "OpenRouterModelId": "meta-llama/llama-3.1-8b-instruct:free",
+    "OpenRouterApiKey": "",
+    "AnthropicModelId": "claude-3-5-sonnet-latest",
+    "AnthropicApiKey": "",
+    "AgentIdentitiesPath": "agents.json"
   }
 }

--- a/MooSharp/Agents/AgentOptions.cs
+++ b/MooSharp/Agents/AgentOptions.cs
@@ -3,10 +3,16 @@ namespace MooSharp.Agents;
 public class AgentOptions
 {
     public const string SectionName = "Agents";
-    
+
     public bool Enabled { get; set; }
     public required string OpenAIModelId { get; set; }
     public required string OpenAIApiKey { get; set; }
     public required string GeminiModelId { get; set; }
     public required string GeminiApiKey { get; set; }
+    public required string OpenRouterModelId { get; set; }
+    public required string OpenRouterApiKey { get; set; }
+    public string OpenRouterEndpoint { get; set; } = "https://openrouter.ai/api/v1";
+    public required string AnthropicModelId { get; set; }
+    public required string AnthropicApiKey { get; set; }
+    public required string AgentIdentitiesPath { get; set; }
 }

--- a/MooSharp/Agents/AgentSource.cs
+++ b/MooSharp/Agents/AgentSource.cs
@@ -4,5 +4,6 @@ public enum AgentSource
 {
     OpenAI,
     Gemini,
-    OpenRouter
+    OpenRouter,
+    Anthropic
 }

--- a/MooSharp/MooSharp.csproj
+++ b/MooSharp/MooSharp.csproj
@@ -7,8 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Anthropic.SDK" Version="5.8.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.11" />
+      <PackageReference Include="Microsoft.SemanticKernel.Connectors.Google" Version="1.67.1-alpha" />
       <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.67.1" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- switch Gemini integration to the Semantic Kernel Google connector rather than raw HTTP calls
- implement Anthropic chat responses via the Anthropic SDK’s IChatClient support
- add the required Google and Anthropic package references to the agent project

## Testing
- dotnet build MooSharp.sln -tl:off /clp:DisableConsoleColor

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923715eb8dc83319fb79b4b847c01b1)