### PR TITLE
Add configurable chat history sliding window

### DIFF
--- a/MooSharp.Web/appsettings.json
+++ b/MooSharp.Web/appsettings.json
@@ -12,6 +12,7 @@
   },
   "Agents": {
     "Enabled": false,
+    "MaxRecentMessages": 20,
     "OpenAIModelId": "gpt-5.1",
     "OpenAIApiKey": "",
     "GeminiModelId": "gemini-1.5-flash",

--- a/MooSharp/Agents/AgentOptions.cs
+++ b/MooSharp/Agents/AgentOptions.cs
@@ -5,6 +5,10 @@ public class AgentOptions
     public const string SectionName = "Agents";
 
     public bool Enabled { get; set; }
+    /// <summary>
+    /// The number of recent non-system chat messages to retain in memory. The system prompt is always preserved.
+    /// </summary>
+    public int MaxRecentMessages { get; set; } = 20;
     public required string OpenAIModelId { get; set; }
     public required string OpenAIApiKey { get; set; }
     public required string GeminiModelId { get; set; }


### PR DESCRIPTION
## Summary
- add a sliding window trim to chat history to prevent unbounded growth
- expose a configurable MaxRecentMessages option with sample configuration default

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923785c9944833187ebb0de705e13fb)