### PR TITLE
Route agent spawning through game engine

### DIFF
--- a/MooSharp/Messaging/GameInput.cs
+++ b/MooSharp/Messaging/GameInput.cs
@@ -1,3 +1,6 @@
+using MooSharp.Agents;
+using MooSharp.Messaging;
+
 namespace MooSharp;
 
 public record GameInput(ConnectionId ConnectionId, InputCommand Command);
@@ -14,6 +17,12 @@ public class LoginCommand : InputCommand
 {
     public required string Username { get; init; }
     public required string Password { get; init; }
+}
+
+public class RegisterAgentCommand : InputCommand
+{
+    public required AgentIdentity Identity { get; init; }
+    public required IPlayerConnection Connection { get; init; }
 }
 
 public class WorldCommand : InputCommand


### PR DESCRIPTION
## Summary
- add a RegisterAgentCommand so agents are registered via the game input channel
- update AgentSpawner to enqueue registration requests instead of mutating the world directly
- have GameEngine handle agent registration and place new connections into their starting rooms

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692378cddc74833190737bcb4c6be437)