### PR TITLE
Log errors when processing world commands

### DIFF
--- a/MooSharp.Web/GameEngine.cs
+++ b/MooSharp.Web/GameEngine.cs
@@ -87,8 +87,9 @@ public class GameEngine(
 
             _ = SendMessagesAsync(result.Messages);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            logger.LogError(ex, "Error processing world command {Command}", command.Command);
             _ = SendMessagesAsync([new(player, new SystemMessageEvent("An unexpected error occurred."))]);
         }
     }


### PR DESCRIPTION
## Summary
- log unexpected exceptions when processing world commands
- keep notifying players about unexpected errors

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237b34535c8331bfcc135c1e0ab63f)