### PR TITLE
Add help command and guide agents with available verbs

### DIFF
--- a/MooSharp.Web/Program.cs
+++ b/MooSharp.Web/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 builder.Services.AddSingleton<World>();
 builder.Services.AddSingleton<CommandParser>();
 builder.Services.AddSingleton<CommandExecutor>();
+builder.Services.AddSingleton<CommandReference>();
 builder.Services.AddSingleton<AgentSpawner>();
 builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IPlayerStore, JsonPlayerStore>();

--- a/MooSharp/Agents/AgentFactory.cs
+++ b/MooSharp/Agents/AgentFactory.cs
@@ -3,10 +3,24 @@ using Microsoft.Extensions.Options;
 
 namespace MooSharp.Agents;
 
-public class AgentFactory(ChannelWriter<GameInput> writer, TimeProvider clock, IOptions<AgentOptions> options)
+public class AgentFactory(
+    ChannelWriter<GameInput> writer,
+    TimeProvider clock,
+    IOptions<AgentOptions> options,
+    CommandReference commandReference)
 {
     public AgentBrain Build(AgentIdentity identity)
     {
-        return new(identity.Name, identity.Persona, identity.Source, writer, options, clock, identity.Cooldown);
+        var availableCommands = commandReference.BuildHelpText();
+
+        return new(
+            identity.Name,
+            identity.Persona,
+            identity.Source,
+            availableCommands,
+            writer,
+            options,
+            clock,
+            identity.Cooldown);
     }
 }

--- a/MooSharp/Commands/CommandReference.cs
+++ b/MooSharp/Commands/CommandReference.cs
@@ -1,0 +1,30 @@
+using System.Text;
+
+namespace MooSharp;
+
+public class CommandReference
+{
+    private readonly IReadOnlyCollection<ICommandDefinition> _definitions;
+
+    public CommandReference(IEnumerable<ICommandDefinition> definitions)
+    {
+        _definitions = definitions
+            .ToArray();
+    }
+
+    public string BuildHelpText()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("Available commands:");
+
+        foreach (var definition in _definitions.OrderBy(d => d.Verbs.First()))
+        {
+            var verbs = string.Join(", ", definition.Verbs);
+
+            sb.AppendLine($"- {verbs}: {definition.Description}");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}

--- a/MooSharp/Commands/Commands/ExamineCommand.cs
+++ b/MooSharp/Commands/Commands/ExamineCommand.cs
@@ -12,6 +12,8 @@ public class ExamineCommandDefinition : ICommandDefinition
 {
     public IReadOnlyCollection<string> Verbs { get; } = ["examine", "view", "look"];
 
+    public string Description => "Inspect yourself, an item, or the room. Usage: examine <target>.";
+
     public ICommand Create(Player player, string args)
         => new ExamineCommand
         {

--- a/MooSharp/Commands/Commands/HelpCommand.cs
+++ b/MooSharp/Commands/Commands/HelpCommand.cs
@@ -1,0 +1,35 @@
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class HelpCommand : CommandBase<HelpCommand>
+{
+    public required Player Player { get; init; }
+}
+
+public class HelpCommandDefinition : ICommandDefinition
+{
+    public IReadOnlyCollection<string> Verbs { get; } = ["/help", "help", "commands"];
+
+    public string Description => "List available commands and their usage.";
+
+    public ICommand Create(Player player, string args)
+        => new HelpCommand
+        {
+            Player = player
+        };
+}
+
+public class HelpHandler(CommandReference commandReference) : IHandler<HelpCommand>
+{
+    public Task<CommandResult> Handle(HelpCommand cmd, CancellationToken cancellationToken = default)
+    {
+        var result = new CommandResult();
+
+        var helpMessage = commandReference.BuildHelpText();
+
+        result.Add(cmd.Player, new SystemMessageEvent(helpMessage));
+
+        return Task.FromResult(result);
+    }
+}

--- a/MooSharp/Commands/Commands/MoveCommand.cs
+++ b/MooSharp/Commands/Commands/MoveCommand.cs
@@ -14,6 +14,8 @@ public class MoveCommandDefinition : ICommandDefinition
 {
     public IReadOnlyCollection<string> Verbs { get; } = ["move", "go", "walk"];
 
+    public string Description => "Move to an adjacent room. Usage: move <exit>.";
+
     public ICommand Create(Player player, string args)
         => new MoveCommand
         {

--- a/MooSharp/Commands/Commands/TakeCommand.cs
+++ b/MooSharp/Commands/Commands/TakeCommand.cs
@@ -15,6 +15,8 @@ public class TakeCommandDefinition : ICommandDefinition
         "take", "grab", "get"
     ];
 
+    public string Description => "Pick up an item from the room. Usage: take <item>.";
+
     public ICommand Create(Player player, string args) =>
         new TakeCommand
         {

--- a/MooSharp/Commands/ICommandDefinition.cs
+++ b/MooSharp/Commands/ICommandDefinition.cs
@@ -11,6 +11,11 @@ public interface ICommandDefinition
     IReadOnlyCollection<string> Verbs { get; }
 
     /// <summary>
+    /// Short description of what the command does, for help text.
+    /// </summary>
+    string Description { get; }
+
+    /// <summary>
     /// Parses raw text into the command.
     /// </summary>
     ICommand Create(Player player, string args);


### PR DESCRIPTION
## Summary
- add a shared command reference and /help command that lists verbs and descriptions
- include command descriptions on existing verbs for richer help output
- inject the help text into agent system prompts so AI players choose valid commands

## Testing
- dotnet build MooSharp.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237de2878c8331b2355129d7bb5290)