### PR TITLE
Limit room descriptions to movement and look

### DIFF
--- a/MooSharp.Web/GameEngine.cs
+++ b/MooSharp.Web/GameEngine.cs
@@ -90,11 +90,6 @@ public class GameEngine(
         {
             var result = await executor.Handle(parsed, ct);
 
-            var description = BuildCurrentRoomDescription(player)
-                .ToString();
-
-            result.Messages.Add(new(player, new RoomDescriptionEvent(description)));
-
             _ = SendMessagesAsync(result.Messages);
         }
         catch (Exception ex)
@@ -203,17 +198,7 @@ public class GameEngine(
             return sb;
         }
 
-        sb.AppendLine(room.Description);
-
-        var otherPlayers = room.PlayersInRoom.Select(s => s.Username).Except([player.Username]);
-
-        sb.AppendLine($"{string.Join(", ", otherPlayers)} are here.");
-
-        var availableExits = room.Exits.Select(s => s.Key);
-
-        var availableExitsMessage = $"Available exits: {string.Join(", ", availableExits)}";
-
-        sb.AppendLine(availableExitsMessage);
+        sb.Append(room.DescribeFor(player));
 
         return sb;
     }

--- a/MooSharp/Actors/Room.cs
+++ b/MooSharp/Actors/Room.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text;
 
 namespace MooSharp;
 
@@ -36,6 +37,24 @@ public class Room
         // Simple fuzzy match
         return Contents.FirstOrDefault(o =>
             o.Name.Contains(keyword, StringComparison.OrdinalIgnoreCase) || o.Keywords.Contains(keyword));
+    }
+
+    public string DescribeFor(Player player)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine(Description);
+
+        var otherPlayers = PlayersInRoom.Select(s => s.Username).Except([player.Username]);
+
+        sb.AppendLine($"{string.Join(", ", otherPlayers)} are here.");
+
+        var availableExits = Exits.Select(s => s.Key);
+        var availableExitsMessage = $"Available exits: {string.Join(", ", availableExits)}";
+
+        sb.AppendLine(availableExitsMessage);
+
+        return sb.ToString();
     }
 
     public override string ToString() => Id.ToString();

--- a/MooSharp/Commands/Commands/ExamineCommand.cs
+++ b/MooSharp/Commands/Commands/ExamineCommand.cs
@@ -30,8 +30,12 @@ public class ExamineHandler(World world) : IHandler<ExamineCommand>
 
         if (string.IsNullOrWhiteSpace(cmd.Target))
         {
-            throw new NotImplementedException(
-                "When no target is specified for 'examine', just print the room's description");
+            var currentLocation = world.GetPlayerLocation(player)
+                ?? throw new InvalidOperationException("Player has no known current location.");
+
+            result.Add(player, new RoomDescriptionEvent(currentLocation.DescribeFor(player)));
+
+            return Task.FromResult(result);
         }
 
         if (cmd.Target is "me")

--- a/MooSharp/Commands/Commands/MoveCommand.cs
+++ b/MooSharp/Commands/Commands/MoveCommand.cs
@@ -48,6 +48,9 @@ public class MoveHandler(World world, ILogger<MoveHandler> logger) : IHandler<Mo
 
         world.MovePlayer(player, exitRoom);
 
+        var description = exitRoom.DescribeFor(player);
+        result.Add(player, new RoomDescriptionEvent(description));
+
         result.BroadcastToAllButPlayer(exitRoom, player, new PlayerArrivedEvent(player, exitRoom));
 
         logger.LogDebug("Move complete");


### PR DESCRIPTION
## Summary
- avoid appending room descriptions for every world command in the engine loop
- add shared room description helper used by move handling and room rendering
- ensure move and look/examine commands emit room descriptions for the actor

## Testing
- dotnet test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69237e4998e48331b4f2fd0e29a8db56)