### PR TITLE
Hash player passwords

### DIFF
--- a/MooSharp/MooSharp.csproj
+++ b/MooSharp/MooSharp.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="Anthropic.SDK" Version="5.8.0" />
+      <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
       <PackageReference Include="Dapper" Version="2.1.35" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />


### PR DESCRIPTION
## Summary
- hash player passwords before persisting new users and verifying logins with bcrypt
- add BCrypt.Net-Next dependency to enable secure password hashing

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923818d4f2c8331ab3a6e6eca9215ad)