### PR TITLE
Sanitize command parsing input

### DIFF
--- a/MooSharp/Commands/CommandParser.cs
+++ b/MooSharp/Commands/CommandParser.cs
@@ -23,9 +23,13 @@ public class CommandParser
 
     public Task<ICommand?> ParseAsync(Player player, string command, CancellationToken token = default)
     {
-        _logger.LogDebug("Parsing player input: {Input}", command);
+        var split = command
+            .Trim()
+            .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        var split = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var sanitized = string.Join(' ', split);
+
+        _logger.LogDebug("Parsing player input: {Input}", sanitized);
 
         var verb = split.FirstOrDefault();
 


### PR DESCRIPTION
## Summary
- trim and normalize player input before parsing commands
- log sanitized command text and reconstruct args from cleaned tokens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238267c918833180249a7258132c60)