### PR TITLE
Use list for player inventory

### DIFF
--- a/MooSharp/Actors/Player.cs
+++ b/MooSharp/Actors/Player.cs
@@ -11,7 +11,7 @@ public class Player
 {
     public PlayerId Id { get; } = PlayerId.New();
     public required IPlayerConnection Connection { get; init; }
-    public Dictionary<string, Object> Inventory { get; } = new();
+    public List<Object> Inventory { get; } = [];
     public required string Username { get; init; }
     public override string ToString() => Username;
 }

--- a/MooSharp/Commands/Commands/ExamineCommand.cs
+++ b/MooSharp/Commands/Commands/ExamineCommand.cs
@@ -43,7 +43,6 @@ public class ExamineHandler(World world) : IHandler<ExamineCommand>
         if (cmd.Target is "me")
         {
             var inventory = player.Inventory
-                .Select(s => s.Value)
                 .ToList();
 
             result.Add(player, new SelfExaminedEvent(player, inventory));

--- a/MooSharp/Commands/Commands/TakeCommand.cs
+++ b/MooSharp/Commands/Commands/TakeCommand.cs
@@ -48,7 +48,7 @@ public class TakeHandler(World world) : IHandler<TakeCommand>
         {
             currentLocation.Contents.Remove(o);
             o.Owner = player;
-            player.Inventory.Add(o.Name, o);
+            player.Inventory.Add(o);
             result.Add(player, new ItemTakenEvent(o));
         }
         else if (o.Owner == player)


### PR DESCRIPTION
## Summary
- change the player inventory to a list to allow duplicate items
- update inventory interactions in commands to work with the list structure

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692382ce81808331bbc821f8178fb50e)