### PR TITLE
Encapsulate world state management

### DIFF
--- a/MooSharp/Commands/Commands/MoveCommand.cs
+++ b/MooSharp/Commands/Commands/MoveCommand.cs
@@ -42,7 +42,7 @@ public class MoveHandler(World world, ILogger<MoveHandler> logger) : IHandler<Mo
             return Task.FromResult(result);
         }
 
-        var exitRoom = world.Rooms[exit];
+        var exitRoom = world.GetRoom(exit);
 
         result.Add(player, new PlayerMovedEvent(player, exitRoom));
 


### PR DESCRIPTION
## Summary
- encapsulate world state behind synchronized helpers to protect shared game data
- update game engine and move command to use the new thread-safe world API

## Testing
- dotnet build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923862d073083318b37d1ddc0c996a7)