### PR TITLE
Handle SignalR reconnections with session tokens

### DIFF
--- a/MooSharp.Web/Components/Pages/Game.razor
+++ b/MooSharp.Web/Components/Pages/Game.razor
@@ -1,6 +1,7 @@
 @page "/game"
 @inject NavigationManager Navigation
 @inject ILogger<Game> Logger
+@inject IJSRuntime JS
 @using System.Text
 @using Microsoft.AspNetCore.SignalR.Client
 @implements IAsyncDisposable
@@ -58,6 +59,7 @@ else
     private string _password = string.Empty;
     private string _loginStatus = string.Empty;
     private bool _isLoggedIn;
+    private string _sessionId = string.Empty;
 
     private bool CanSubmitCredentials =>
         _hubConnection?.State == HubConnectionState.Connected
@@ -66,8 +68,13 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        _sessionId = await GetOrCreateSessionIdAsync();
+
         _hubConnection = new HubConnectionBuilder()
-            .WithUrl(Navigation.ToAbsoluteUri("/moohub"))
+            .WithUrl(Navigation.ToAbsoluteUri("/moohub"), options =>
+            {
+                options.AccessTokenProvider = () => Task.FromResult<string?>(_sessionId);
+            })
             .Build();
 
         _hubConnection.On<string>("ReceiveMessage",
@@ -196,6 +203,24 @@ else
             _loginStatus = $"Failed to send {commandName.ToLowerInvariant()} request.";
             throw;
         }
+    }
+
+    private async Task<string> GetOrCreateSessionIdAsync()
+    {
+        const string sessionStorageKey = "mooSharpSession";
+
+        var existingSessionId = await JS.InvokeAsync<string?>("localStorage.getItem", sessionStorageKey);
+
+        if (!string.IsNullOrWhiteSpace(existingSessionId))
+        {
+            return existingSessionId;
+        }
+
+        var newSessionId = Guid.NewGuid().ToString();
+
+        await JS.InvokeVoidAsync("localStorage.setItem", sessionStorageKey, newSessionId);
+
+        return newSessionId;
     }
 
     public async ValueTask DisposeAsync()

--- a/MooSharp/Actors/Player.cs
+++ b/MooSharp/Actors/Player.cs
@@ -10,7 +10,7 @@ public readonly record struct PlayerId(Guid Value)
 public class Player
 {
     public PlayerId Id { get; } = PlayerId.New();
-    public required IPlayerConnection Connection { get; init; }
+    public required IPlayerConnection Connection { get; set; }
     public List<Object> Inventory { get; } = [];
     public required string Username { get; init; }
     public override string ToString() => Username;

--- a/MooSharp/Messaging/GameInput.cs
+++ b/MooSharp/Messaging/GameInput.cs
@@ -3,7 +3,7 @@ using MooSharp.Messaging;
 
 namespace MooSharp;
 
-public record GameInput(ConnectionId ConnectionId, InputCommand Command);
+public record GameInput(ConnectionId ConnectionId, InputCommand Command, string? SessionToken = null);
 
 public abstract class InputCommand;
 
@@ -31,3 +31,5 @@ public class WorldCommand : InputCommand
 }
 
 public class DisconnectCommand : InputCommand;
+
+public class ReconnectCommand : InputCommand;


### PR DESCRIPTION
## Summary
- persist a client session identifier and send it with SignalR connections and commands
- track session-to-player mappings in the game engine to rebind players when reconnects occur
- allow player connection updates so sessions survive SignalR connection ID changes

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924223c3758833191213bc3833b1fcf)