### PR TITLE
Add cancellation and disposal to agent brain processing

### DIFF
--- a/MooSharp/Agents/AgentFactory.cs
+++ b/MooSharp/Agents/AgentFactory.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Channels;
 using Microsoft.Extensions.Options;
 
@@ -9,7 +10,7 @@ public class AgentFactory(
     IOptions<AgentOptions> options,
     CommandReference commandReference)
 {
-    public AgentBrain Build(AgentIdentity identity)
+    public AgentBrain Build(AgentIdentity identity, CancellationToken cancellationToken)
     {
         var availableCommands = commandReference.BuildHelpText();
 
@@ -21,6 +22,7 @@ public class AgentFactory(
             writer,
             options,
             clock,
-            identity.Cooldown);
+            identity.Cooldown,
+            cancellationToken);
     }
 }

--- a/MooSharp/Agents/AgentSpawner.cs
+++ b/MooSharp/Agents/AgentSpawner.cs
@@ -1,6 +1,7 @@
 namespace MooSharp.Agents;
 
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Channels;
 using Microsoft.Extensions.Options;
 using MooSharp;
@@ -44,7 +45,7 @@ public class AgentSpawner(AgentFactory factory, ChannelWriter<GameInput> writer,
 
     private async Task SpawnAgentAsync(AgentIdentity identity, CancellationToken cancellationToken)
     {
-        var brain = factory.Build(identity);
+        var brain = factory.Build(identity, cancellationToken);
 
         var registerAgentCommand = new RegisterAgentCommand
         {


### PR DESCRIPTION
## Summary
- link AgentBrain processing loop to cancellation and track its task instead of fire-and-forget
- dispose agent resources to cancel processing and complete channels cleanly
- pass host cancellation through factory/spawner into each agent brain

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692426c899c4833190178265173ed39a)