### PR TITLE
Delay JS interop until after first render

### DIFF
--- a/MooSharp.Web/Components/Pages/Game.razor
+++ b/MooSharp.Web/Components/Pages/Game.razor
@@ -66,7 +66,21 @@ else
         && !string.IsNullOrWhiteSpace(_username)
         && !string.IsNullOrWhiteSpace(_password);
 
-    protected override async Task OnInitializedAsync()
+    private bool _initialized;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender || _initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+
+        await InitializeAsync();
+    }
+
+    private async Task InitializeAsync()
     {
         _sessionId = await GetOrCreateSessionIdAsync();
 
@@ -130,6 +144,8 @@ else
         {
             _gameOutput.AppendLine($"Starting hub failed: {ex.Message}");
         }
+
+        await InvokeAsync(StateHasChanged);
     }
 
     private async Task HandleKeyDown(KeyboardEventArgs e)


### PR DESCRIPTION
## Summary
- move Game component initialization to run after first render
- ensure session id storage and SignalR connection setup occur when JS interop is allowed

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924279eaf3883319721336604d02696)