### PR TITLE
Add say command for room chat

### DIFF
--- a/MooSharp/Commands/Commands/SayCommand.cs
+++ b/MooSharp/Commands/Commands/SayCommand.cs
@@ -1,0 +1,51 @@
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class SayCommand : CommandBase<SayCommand>
+{
+    public required Player Player { get; init; }
+    public required string Message { get; init; }
+}
+
+public class SayCommandDefinition : ICommandDefinition
+{
+    public IReadOnlyCollection<string> Verbs { get; } = ["say"];
+
+    public string Description => "Send a message to everyone in your current room. Usage: say <message>.";
+
+    public ICommand Create(Player player, string args)
+        => new SayCommand
+        {
+            Player = player,
+            Message = args
+        };
+}
+
+public class SayHandler(World world) : IHandler<SayCommand>
+{
+    public Task<CommandResult> Handle(SayCommand cmd, CancellationToken cancellationToken = default)
+    {
+        var result = new CommandResult();
+
+        var content = cmd.Message.Trim();
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            result.Add(cmd.Player, new SystemMessageEvent("Say what?"));
+
+            return Task.FromResult(result);
+        }
+
+        var room = world.GetPlayerLocation(cmd.Player)
+            ?? throw new InvalidOperationException("Player has no known current location.");
+
+        var gameEvent = new PlayerSaidEvent(cmd.Player, content);
+
+        result.Add(cmd.Player, gameEvent);
+
+        result.BroadcastToAllButPlayer(room, cmd.Player, gameEvent);
+
+        return Task.FromResult(result);
+    }
+}

--- a/MooSharp/Messaging/EventFormatters.cs
+++ b/MooSharp/Messaging/EventFormatters.cs
@@ -111,3 +111,11 @@ public class ObjectExaminedEventFormatter : IGameEventFormatter<ObjectExaminedEv
 
     public string FormatForObserver(ObjectExaminedEvent gameEvent) => gameEvent.Item.Description;
 }
+
+public class PlayerSaidEventFormatter : IGameEventFormatter<PlayerSaidEvent>
+{
+    public string FormatForActor(PlayerSaidEvent gameEvent) => $"You say, \"{gameEvent.Message}\"";
+
+    public string FormatForObserver(PlayerSaidEvent gameEvent) =>
+        $"{gameEvent.Player.Username} says, \"{gameEvent.Message}\"";
+}

--- a/MooSharp/Messaging/GameEvents.cs
+++ b/MooSharp/Messaging/GameEvents.cs
@@ -23,3 +23,5 @@ public record ItemOwnedByOtherEvent(Object Item, Player Owner) : IGameEvent;
 public record SelfExaminedEvent(Player Player, IReadOnlyCollection<Object> Inventory) : IGameEvent;
 
 public record ObjectExaminedEvent(Object Item) : IGameEvent;
+
+public record PlayerSaidEvent(Player Player, string Message) : IGameEvent;


### PR DESCRIPTION
## Summary
- add a say command so players can speak to everyone in their current room
- broadcast spoken messages with a new PlayerSaidEvent and formatter for actors and observers
- guard against empty say input with a friendly system response

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692430f4b5ac8331853cc85e57202d2f)