### PR TITLE
Add room messaging metadata for entry and exit

### DIFF
--- a/MooSharp.Web/world.json
+++ b/MooSharp.Web/world.json
@@ -3,24 +3,36 @@
     {
       "Name": "atrium",
       "Description": "A beautiful atrium.",
+      "LongDescription": "A beautiful atrium with sun pouring through the glass ceiling. Benches line the walls beneath hanging plants.",
+      "EnterText": "You step into the atrium.",
+      "ExitText": "You leave the atrium.",
       "Slug": "atrium",
       "ConnectedRooms": ["side-room"]
     },
     {
       "Name": "side-room",
       "Description": "A small side-room for drinking coffee.",
+      "LongDescription": "A small side-room for drinking coffee, complete with a humming kettle and a few mismatched stools.",
+      "EnterText": "You shuffle into the side-room.",
+      "ExitText": "You step out of the side-room.",
       "Slug": "side-room",
       "ConnectedRooms": ["atrium", "closet"]
     },
     {
       "Name": "closet",
       "Description": "A cramped and dark closet.",
+      "LongDescription": "A cramped and dark closet filled with the scent of dust and old mops. Shelves crowd the narrow walls.",
+      "EnterText": "You head into the closet.",
+      "ExitText": "You leave the closet.",
       "Slug": "closet",
       "ConnectedRooms": ["side-room", "dark-world"]
     },
     {
       "Name": "dark world",
       "Description": "A secret place.",
+      "LongDescription": "A secret place hidden behind the closet. The air here is still and the walls vanish into darkness.",
+      "EnterText": "You cross over into the dark world.",
+      "ExitText": "You slip away from the dark world.",
       "Slug": "dark-world",
       "ConnectedRooms": ["closet"]
     }

--- a/MooSharp/Actors/Room.cs
+++ b/MooSharp/Actors/Room.cs
@@ -28,6 +28,9 @@ public class Room : IContainer
     public RoomId Id { get; init; }
     public required string Name { get; init; }
     public required string Description { get; init; }
+    public required string LongDescription { get; init; }
+    public required string EnterText { get; init; }
+    public required string ExitText { get; init; }
     private readonly List<Object> _contents = new();
     public IReadOnlyCollection<Object> Contents => _contents;
     public Dictionary<string, RoomId> Exits { get; } = new(StringComparer.OrdinalIgnoreCase);
@@ -38,11 +41,11 @@ public class Room : IContainer
         return this.FindObjectInContainer(keyword);
     }
 
-    public string DescribeFor(Player player)
+    public string DescribeFor(Player player, bool useLongDescription = false)
     {
         var sb = new StringBuilder();
 
-        sb.AppendLine(Description);
+        sb.AppendLine(useLongDescription ? LongDescription : Description);
 
         var otherPlayers = PlayersInRoom.Select(s => s.Username).Except([player.Username]);
 

--- a/MooSharp/Commands/Commands/ExamineCommand.cs
+++ b/MooSharp/Commands/Commands/ExamineCommand.cs
@@ -35,7 +35,7 @@ public class ExamineHandler(World world) : IHandler<ExamineCommand>
             var currentLocation = world.GetPlayerLocation(player)
                 ?? throw new InvalidOperationException("Player has no known current location.");
 
-            result.Add(player, new RoomDescriptionEvent(currentLocation.DescribeFor(player)));
+            result.Add(player, new RoomDescriptionEvent(currentLocation.DescribeFor(player, useLongDescription: true)));
 
             return Task.FromResult(result);
         }

--- a/MooSharp/Commands/Commands/MoveCommand.cs
+++ b/MooSharp/Commands/Commands/MoveCommand.cs
@@ -44,6 +44,7 @@ public class MoveHandler(World world, ILogger<MoveHandler> logger) : IHandler<Mo
 
         var exitRoom = world.Rooms[exit];
 
+        result.Add(player, new PlayerDepartedEvent(player, originRoom, cmd.TargetExit));
         result.Add(player, new PlayerMovedEvent(player, exitRoom));
 
         result.BroadcastToAllButPlayer(originRoom, player, new PlayerDepartedEvent(player, originRoom, cmd.TargetExit));

--- a/MooSharp/Messaging/EventFormatters.cs
+++ b/MooSharp/Messaging/EventFormatters.cs
@@ -25,28 +25,28 @@ public class ExitNotFoundEventFormatter : IGameEventFormatter<ExitNotFoundEvent>
 
 public class PlayerMovedEventFormatter : IGameEventFormatter<PlayerMovedEvent>
 {
-    public string FormatForActor(PlayerMovedEvent gameEvent) => $"You head to {gameEvent.Destination.Description}.";
+    public string FormatForActor(PlayerMovedEvent gameEvent) => gameEvent.Destination.EnterText;
 
     public string FormatForObserver(PlayerMovedEvent gameEvent) =>
-        $"{gameEvent.Player.Username} moved towards {gameEvent.Destination.Description}.";
+        $"{gameEvent.Player.Username} arrives.";
 }
 
 public class PlayerDepartedEventFormatter : IGameEventFormatter<PlayerDepartedEvent>
 {
     public string FormatForActor(PlayerDepartedEvent gameEvent) =>
-        $"You head out through {gameEvent.ExitName}.";
+        gameEvent.Origin.ExitText;
 
     public string FormatForObserver(PlayerDepartedEvent gameEvent) =>
-        $"{gameEvent.Player.Username} went to {gameEvent.ExitName}";
+        $"{gameEvent.Player.Username} leaves.";
 }
 
 public class PlayerArrivedEventFormatter : IGameEventFormatter<PlayerArrivedEvent>
 {
     public string FormatForActor(PlayerArrivedEvent gameEvent) =>
-        $"You arrived in {gameEvent.Destination.Description}.";
+        gameEvent.Destination.EnterText;
 
     public string FormatForObserver(PlayerArrivedEvent gameEvent) =>
-        $"{gameEvent.Player.Username} arrived";
+        $"{gameEvent.Player.Username} arrives.";
 }
 
 public class ItemNotFoundEventFormatter : IGameEventFormatter<ItemNotFoundEvent>

--- a/MooSharp/Persistence/Dtos/RoomDto.cs
+++ b/MooSharp/Persistence/Dtos/RoomDto.cs
@@ -6,7 +6,10 @@ public class RoomDto
 {
     public required string Name { get; set; }
     public required string Description { get; set; }
-    
+    public required string LongDescription { get; set; }
+    public required string EnterText { get; set; }
+    public required string ExitText { get; set; }
+
     [JsonConverter(typeof(RoomIdJsonConverter))]
     public required RoomId Slug { get; set; }
     public IReadOnlyList<string> ConnectedRooms { get; set; } = [];

--- a/MooSharp/World.cs
+++ b/MooSharp/World.cs
@@ -65,6 +65,9 @@ public class World(IOptions<AppOptions> options, ILogger<World> logger)
                     Id = r.Slug,
                     Name = r.Name,
                     Description = r.Description,
+                    LongDescription = r.LongDescription,
+                    EnterText = r.EnterText,
+                    ExitText = r.ExitText,
                 });
         
         // Connect exits.


### PR DESCRIPTION
## Summary
- extend room data to include long descriptions plus entry and exit text and populate world data
- update move and examine flows to use new description and messaging fields
- simplify observer notifications for arrivals and departures

## Testing
- dotnet test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924349a92948331ac7feb88e62f5492)