### PR TITLE
Add logging to agent brain

### DIFF
--- a/MooSharp/Agents/AgentFactory.cs
+++ b/MooSharp/Agents/AgentFactory.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace MooSharp.Agents;
@@ -8,11 +9,13 @@ public class AgentFactory(
     ChannelWriter<GameInput> writer,
     TimeProvider clock,
     IOptions<AgentOptions> options,
-    CommandReference commandReference)
+    CommandReference commandReference,
+    ILoggerFactory loggerFactory)
 {
     public AgentBrain Build(AgentIdentity identity)
     {
         var availableCommands = commandReference.BuildHelpText();
+        var logger = loggerFactory.CreateLogger($"{typeof(AgentBrain).FullName}[{identity.Name}]");
 
         return new(
             identity.Name,
@@ -22,6 +25,7 @@ public class AgentFactory(
             writer,
             options,
             clock,
+            logger,
             identity.Cooldown);
     }
 }


### PR DESCRIPTION
## Summary
- create an agent-specific logger using ILoggerFactory and pass it to AgentBrain
- add informational and debug logs for message processing, cooldowns, and command dispatch
- log errors during processing and cleanly log lifecycle events

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243a63528c833199cbeace617b8165)