### PR TITLE
Refine world creation and occupant management

### DIFF
--- a/MooSharp.Web/GameEngine.cs
+++ b/MooSharp.Web/GameEngine.cs
@@ -104,7 +104,7 @@ public class GameEngine(
         }
 
         await playerStore.SavePlayer(player, location);
-        location.PlayersInRoom.Remove(player);
+        world.RemovePlayer(player);
 
         world.Players.Remove(connectionId.Value);
 

--- a/MooSharp.Web/Program.cs
+++ b/MooSharp.Web/Program.cs
@@ -37,9 +37,5 @@ app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
 
 app.MapHub<MooHub>("/moohub");
 
-var world = app.Services.GetRequiredService<World>();
-
-await world.InitializeAsync();
-
 await app.RunAsync();
 

--- a/MooSharp.Web/ServiceCollectionExtensions.cs
+++ b/MooSharp.Web/ServiceCollectionExtensions.cs
@@ -10,7 +10,13 @@ public static class ServiceCollectionExtensions
 {
     public static void AddMooSharpServices(this IServiceCollection services, IConfiguration config)
     {
-        services.AddSingleton<World>();
+        services.AddSingleton<WorldFactory>();
+        services.AddSingleton(sp =>
+        {
+            var factory = sp.GetRequiredService<WorldFactory>();
+
+            return factory.CreateWorld();
+        });
         services.AddSingleton<CommandParser>();
         services.AddSingleton<CommandExecutor>();
         services.AddSingleton<CommandReference>();

--- a/MooSharp/Actors/Room.cs
+++ b/MooSharp/Actors/Room.cs
@@ -32,9 +32,10 @@ public class Room : IContainer
     public required string EnterText { get; init; }
     public required string ExitText { get; init; }
     private readonly List<Object> _contents = new();
+    private readonly List<Player> _playersInRoom = new();
     public IReadOnlyCollection<Object> Contents => _contents;
     public Dictionary<string, RoomId> Exits { get; } = new(StringComparer.OrdinalIgnoreCase);
-    public List<Player> PlayersInRoom { get; } = new();
+    public IReadOnlyCollection<Player> PlayersInRoom => _playersInRoom;
 
     public SearchResult FindObjects(string query) => _contents.FindObjects(query);
 
@@ -69,6 +70,20 @@ public class Room : IContainer
     void IContainer.AddToContents(Object item) => _contents.Add(item);
 
     bool IContainer.RemoveFromContents(Object item) => _contents.Remove(item);
+
+    internal bool AddPlayer(Player player)
+    {
+        if (_playersInRoom.Contains(player))
+        {
+            return false;
+        }
+
+        _playersInRoom.Add(player);
+
+        return true;
+    }
+
+    internal bool RemovePlayer(Player player) => _playersInRoom.Remove(player);
 }
 
 public enum SearchStatus

--- a/MooSharp/World.cs
+++ b/MooSharp/World.cs
@@ -1,131 +1,18 @@
-using System.Text.Json;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-
 namespace MooSharp;
 
-public class World(IOptions<AppOptions> options, ILogger<World> logger)
+public class World
 {
     public Dictionary<string, Player> Players { get; } = [];
-    public Dictionary<RoomId, Room> Rooms => _rooms;
-    private Dictionary<RoomId, Room> _rooms = [];
+    public IReadOnlyDictionary<RoomId, Room> Rooms => _rooms;
+    private readonly Dictionary<RoomId, Room> _rooms;
 
     private readonly Dictionary<Player, Room> _playerLocations = [];
 
-    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    public World(IEnumerable<Room> rooms)
     {
-        var dto = await GetWorldDto(cancellationToken);
+        ArgumentNullException.ThrowIfNull(rooms);
 
-        _rooms = CreateRooms(dto);
-        CreateObjects(dto, _rooms);
-    }
-
-    private async Task<WorldDto> GetWorldDto(CancellationToken cancellationToken)
-    {
-        var path = options.Value.WorldDataFilepath;
-
-        if (string.IsNullOrEmpty(path))
-        {
-            throw new InvalidOperationException("WorldDataFilepath is not set.");
-        }
-
-        var raw = await File.ReadAllTextAsync(path, cancellationToken);
-
-        var dto = JsonSerializer.Deserialize<WorldDto>(raw);
-
-        if (dto is null)
-        {
-            throw new InvalidOperationException("World data failed to deserialize.");
-        }
-
-        if (!dto.Rooms.Any())
-        {
-            throw new InvalidOperationException("Room data failed to deserialize.");
-        }
-
-        var slugs = dto
-            .Rooms
-            .Select(s => s.Slug)
-            .ToList();
-
-        var filtered = slugs
-            .Distinct()
-            .ToList();
-
-        if (slugs.Count != filtered.Count)
-        {
-            throw new InvalidOperationException("At least one slug was duplicated across rooms.");
-        }
-
-        return dto;
-    }
-
-    private Dictionary<RoomId, Room> CreateRooms(WorldDto dto)
-    {
-        var roomActorsBySlug = dto.Rooms.ToDictionary(r => r.Slug,
-            r => new Room
-                {
-                    Id = r.Slug,
-                    Name = r.Name,
-                    Description = r.Description,
-                    LongDescription = r.LongDescription,
-                    EnterText = r.EnterText,
-                    ExitText = r.ExitText,
-                });
-        
-        // Connect exits.
-        foreach (var roomDto in dto.Rooms)
-        {
-            try
-            {
-                logger.LogInformation("Initializing exits for {Room}", roomDto.Slug);
-
-                var currentRoomActor = roomActorsBySlug[roomDto.Slug];
-
-                var exits = roomDto.ConnectedRooms.ToDictionary(exitSlug => exitSlug,
-                    exitSlug =>
-                    {
-                        if (!roomActorsBySlug.ContainsKey(exitSlug))
-                        {
-                            logger.LogError("Missing slug {Slug} for room {Room}", exitSlug, roomDto.Slug);
-                        }
-
-                        return roomActorsBySlug[exitSlug];
-                    });
-
-                foreach (var exit in exits)
-                {
-                    currentRoomActor.Exits.Add(exit.Key, exit.Value.Id);
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogError(ex, "Failed to initialize exits for {Room}", roomDto.Slug);
-
-                throw;
-            }
-        }
-
-        return roomActorsBySlug;
-    }
-
-    private void CreateObjects(WorldDto dto, Dictionary<RoomId, Room> rooms)
-    {
-        foreach (var objectDto in dto.Objects.Where(s => s.RoomSlug is not null))
-        {
-            if (!rooms.TryGetValue(objectDto.RoomSlug!, out var room))
-            {
-                continue;
-            }
-
-            var obj = new Object
-            {
-                Description = objectDto.Description,
-                Name = objectDto.Name
-            };
-
-            obj.MoveTo(room);
-        }
+        _rooms = rooms.ToDictionary(r => r.Id);
     }
 
     public Room? GetPlayerLocation(Player player)
@@ -146,13 +33,18 @@ public class World(IOptions<AppOptions> options, ILogger<World> logger)
             return;
         }
 
-        origin?.PlayersInRoom.Remove(player);
+        origin?.RemovePlayer(player);
 
-        if (!destination.PlayersInRoom.Contains(player))
-        {
-            destination.PlayersInRoom.Add(player);
-        }
-        
+        destination.AddPlayer(player);
+
         _playerLocations[player] = destination;
+    }
+
+    public void RemovePlayer(Player player)
+    {
+        if (_playerLocations.Remove(player, out var location))
+        {
+            location.RemovePlayer(player);
+        }
     }
 }

--- a/MooSharp/WorldFactory.cs
+++ b/MooSharp/WorldFactory.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MooSharp;
+
+public class WorldFactory(IOptions<AppOptions> options, ILogger<WorldFactory> logger)
+{
+    public World CreateWorld()
+    {
+        var dto = GetWorldDto();
+
+        var rooms = CreateRooms(dto);
+        CreateObjects(dto, rooms);
+
+        return new World(rooms.Values);
+    }
+
+    public World CreateWorld(List<Room> rooms)
+    {
+        ArgumentNullException.ThrowIfNull(rooms);
+
+        return new World(rooms);
+    }
+
+    private WorldDto GetWorldDto()
+    {
+        var path = options.Value.WorldDataFilepath;
+
+        if (string.IsNullOrEmpty(path))
+        {
+            throw new InvalidOperationException("WorldDataFilepath is not set.");
+        }
+
+        var raw = File.ReadAllText(path);
+
+        var dto = JsonSerializer.Deserialize<WorldDto>(raw);
+
+        if (dto is null)
+        {
+            throw new InvalidOperationException("World data failed to deserialize.");
+        }
+
+        if (!dto.Rooms.Any())
+        {
+            throw new InvalidOperationException("Room data failed to deserialize.");
+        }
+
+        var slugs = dto
+            .Rooms
+            .Select(s => s.Slug)
+            .ToList();
+
+        var filtered = slugs
+            .Distinct()
+            .ToList();
+
+        if (slugs.Count != filtered.Count)
+        {
+            throw new InvalidOperationException("At least one slug was duplicated across rooms.");
+        }
+
+        return dto;
+    }
+
+    private Dictionary<RoomId, Room> CreateRooms(WorldDto dto)
+    {
+        var roomActorsBySlug = dto.Rooms.ToDictionary(r => r.Slug,
+            r => new Room
+            {
+                Id = r.Slug,
+                Name = r.Name,
+                Description = r.Description,
+                LongDescription = r.LongDescription,
+                EnterText = r.EnterText,
+                ExitText = r.ExitText,
+            });
+
+        // Connect exits.
+        foreach (var roomDto in dto.Rooms)
+        {
+            try
+            {
+                logger.LogInformation("Initializing exits for {Room}", roomDto.Slug);
+
+                var currentRoomActor = roomActorsBySlug[roomDto.Slug];
+
+                var exits = roomDto.ConnectedRooms.ToDictionary(exitSlug => exitSlug,
+                    exitSlug =>
+                    {
+                        if (!roomActorsBySlug.ContainsKey(exitSlug))
+                        {
+                            logger.LogError("Missing slug {Slug} for room {Room}", exitSlug, roomDto.Slug);
+                        }
+
+                        return roomActorsBySlug[exitSlug];
+                    });
+
+                foreach (var exit in exits)
+                {
+                    currentRoomActor.Exits.Add(exit.Key, exit.Value.Id);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to initialize exits for {Room}", roomDto.Slug);
+
+                throw;
+            }
+        }
+
+        return roomActorsBySlug;
+    }
+
+    private void CreateObjects(WorldDto dto, Dictionary<RoomId, Room> rooms)
+    {
+        foreach (var objectDto in dto.Objects.Where(s => s.RoomSlug is not null))
+        {
+            if (!rooms.TryGetValue(objectDto.RoomSlug!, out var room))
+            {
+                continue;
+            }
+
+            var obj = new Object
+            {
+                Description = objectDto.Description,
+                Name = objectDto.Name
+            };
+
+            obj.MoveTo(room);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- make WorldFactory creation synchronous to avoid blocking DI and simplify tests
- expose room occupants as read-only collections with controlled movement APIs
- update game engine and command handler tests to use world-managed player movement

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692448405be083318813c8599afe3ecf)