### PR TITLE
Refine agent startup and prompt sourcing

### DIFF
--- a/MooSharp.Web/ServiceCollectionExtensions.cs
+++ b/MooSharp.Web/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<CommandParser>();
         services.AddSingleton<CommandExecutor>();
         services.AddSingleton<CommandReference>();
+        services.AddSingleton<IAgentPromptProvider, AgentPromptProvider>();
         services.AddSingleton<AgentSpawner>();
         services.AddSingleton<AgentFactory>();
         services.AddSingleton(TimeProvider.System);

--- a/MooSharp.Web/appsettings.json
+++ b/MooSharp.Web/appsettings.json
@@ -21,6 +21,7 @@
     "OpenRouterApiKey": "",
     "AnthropicModelId": "claude-3-5-sonnet-latest",
     "AnthropicApiKey": "",
-    "AgentIdentitiesPath": "agents.json"
+    "AgentIdentitiesPath": "agents.json",
+    "SystemPromptTemplatePath": "Agents/SystemPrompt.hbs"
   }
 }

--- a/MooSharp/Agents/AgentFactory.cs
+++ b/MooSharp/Agents/AgentFactory.cs
@@ -9,21 +9,20 @@ public class AgentFactory(
     ChannelWriter<GameInput> writer,
     TimeProvider clock,
     IOptions<AgentOptions> options,
-    CommandReference commandReference,
+    IAgentPromptProvider promptProvider,
     ILoggerFactory loggerFactory)
 {
     public AgentBrain Build(AgentIdentity identity)
     {
-        var availableCommands = commandReference.BuildHelpText();
         var logger = loggerFactory.CreateLogger($"{typeof(AgentBrain).FullName}[{identity.Name}]");
 
         return new(
             identity.Name,
             identity.Persona,
             identity.Source,
-            availableCommands,
             writer,
             options,
+            promptProvider,
             clock,
             logger,
             identity.Cooldown);

--- a/MooSharp/Agents/AgentOptions.cs
+++ b/MooSharp/Agents/AgentOptions.cs
@@ -19,4 +19,5 @@ public class AgentOptions
     public required string AnthropicModelId { get; set; }
     public required string AnthropicApiKey { get; set; }
     public required string AgentIdentitiesPath { get; set; }
+    public required string SystemPromptTemplatePath { get; set; }
 }

--- a/MooSharp/Agents/AgentPromptProvider.cs
+++ b/MooSharp/Agents/AgentPromptProvider.cs
@@ -1,0 +1,59 @@
+using HandlebarsDotNet;
+using Microsoft.Extensions.Options;
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace MooSharp.Agents;
+
+public class AgentPromptProvider(IOptions<AgentOptions> options, CommandReference commandReference) : IAgentPromptProvider
+{
+    private readonly SemaphoreSlim _templateLock = new(1, 1);
+    private HandlebarsTemplate<object, object>? _compiledTemplate;
+
+    public async Task<string> GetSystemPromptAsync(string name,
+        string persona,
+        CancellationToken cancellationToken = default)
+    {
+        await EnsureTemplateAsync(cancellationToken).ConfigureAwait(false);
+
+        return _compiledTemplate!(new
+        {
+            Name = name,
+            Persona = persona,
+            AvailableCommands = commandReference.BuildHelpText()
+        });
+    }
+
+    public Task<ChatHistory> PrepareHistoryAsync(ChatHistory history, CancellationToken cancellationToken = default)
+    {
+        return Task.FromResult(history);
+    }
+
+    private async Task EnsureTemplateAsync(CancellationToken cancellationToken)
+    {
+        if (_compiledTemplate is not null)
+        {
+            return;
+        }
+
+        await _templateLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (_compiledTemplate is not null)
+            {
+                return;
+            }
+
+            var templatePath = Path.Combine(AppContext.BaseDirectory, options.Value.SystemPromptTemplatePath);
+            templatePath = Path.GetFullPath(templatePath);
+            var template = await File.ReadAllTextAsync(templatePath, cancellationToken)
+                .ConfigureAwait(false);
+
+            _compiledTemplate = Handlebars.Compile(template);
+        }
+        finally
+        {
+            _templateLock.Release();
+        }
+    }
+}

--- a/MooSharp/Agents/AgentSpawner.cs
+++ b/MooSharp/Agents/AgentSpawner.cs
@@ -47,7 +47,7 @@ public class AgentSpawner(AgentFactory factory, ChannelWriter<GameInput> writer,
     {
         var brain = factory.Build(identity);
 
-        brain.Start(cancellationToken);
+        await brain.StartAsync(cancellationToken);
         
         var registerAgentCommand = new RegisterAgentCommand
         {

--- a/MooSharp/Agents/IAgentPromptProvider.cs
+++ b/MooSharp/Agents/IAgentPromptProvider.cs
@@ -1,0 +1,12 @@
+using Microsoft.SemanticKernel.ChatCompletion;
+
+namespace MooSharp.Agents;
+
+public interface IAgentPromptProvider
+{
+    Task<string> GetSystemPromptAsync(string name,
+        string persona,
+        CancellationToken cancellationToken = default);
+
+    Task<ChatHistory> PrepareHistoryAsync(ChatHistory history, CancellationToken cancellationToken = default);
+}

--- a/MooSharp/Agents/SystemPrompt.hbs
+++ b/MooSharp/Agents/SystemPrompt.hbs
@@ -1,0 +1,4 @@
+You are a player in a text-based adventure game. Your name is {{Name}}.
+{{Persona}}
+Use only the commands listed below, and respond with a single command starting with the command verb.
+{{AvailableCommands}}

--- a/MooSharp/MooSharp.csproj
+++ b/MooSharp/MooSharp.csproj
@@ -10,11 +10,18 @@
       <PackageReference Include="Anthropic.SDK" Version="5.8.0" />
       <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
       <PackageReference Include="Dapper" Version="2.1.35" />
+      <PackageReference Include="Handlebars.Net" Version="2.1.5" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.11" />
       <PackageReference Include="Microsoft.SemanticKernel.Connectors.Google" Version="1.67.1-alpha" />
       <PackageReference Include="Microsoft.SemanticKernel.Connectors.OpenAI" Version="1.67.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <Content Include="Agents/SystemPrompt.hbs">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- have the prompt provider assemble available commands instead of AgentBrain
- initialize agent system prompts asynchronously during startup and update spawner to await it
- simplify factory and interface signatures after removing the available commands parameter

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69244aedd8688331aa7685a419d2db57)