### PR TITLE
Refactor command parser tests and share doubles

### DIFF
--- a/MooSharp.Tests/CommandHandlerTests.cs
+++ b/MooSharp.Tests/CommandHandlerTests.cs
@@ -451,13 +451,6 @@ public class CommandHandlerTests
         };
     }
 
-    private sealed class TestPlayerConnection : IPlayerConnection
-    {
-        public string Id { get; } = Guid.NewGuid().ToString();
-
-        public Task SendMessageAsync(string message) => Task.CompletedTask;
-    }
-
     private sealed class InMemoryWorldStore : IWorldStore
     {
         private readonly List<Room> _rooms = new();

--- a/MooSharp.Tests/CommandParserTests.cs
+++ b/MooSharp.Tests/CommandParserTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MooSharp;
+
+namespace MooSharp.Tests;
+
+public class CommandParserTests
+{
+    [Fact]
+    public async Task ParseAsync_ReturnsNullForEmptyOrWhitespaceInput()
+    {
+        var parser = new CommandParser(NullLogger<CommandParser>.Instance, Enumerable.Empty<ICommandDefinition>());
+        var player = CreatePlayer();
+
+        var result = await parser.ParseAsync(player, "   \t  ");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ParseAsync_ReturnsNullForUnknownVerbEvenWhenDefinitionsExist()
+    {
+        var definition = new RecordingDefinition("known");
+        var parser = new CommandParser(NullLogger<CommandParser>.Instance, new[] { definition });
+        var player = CreatePlayer();
+
+        var result = await parser.ParseAsync(player, "unknown args");
+
+        Assert.Null(result);
+        Assert.Null(definition.LastArgs);
+    }
+
+    [Fact]
+    public async Task ParseAsync_DoesNotMatchMultiWordVerbs()
+    {
+        var definition = new RecordingDefinition("look at");
+        var parser = new CommandParser(NullLogger<CommandParser>.Instance, new[] { definition });
+        var player = CreatePlayer();
+
+        var result = await parser.ParseAsync(player, "look at shiny sword");
+
+        Assert.Null(result);
+        Assert.Null(definition.LastArgs);
+    }
+
+    [Fact]
+    public async Task ParseAsync_MatchesVerbCaseInsensitivelyAndPassesNormalizedArgs()
+    {
+        var definition = new RecordingDefinition("say");
+        var parser = new CommandParser(NullLogger<CommandParser>.Instance, new[] { definition });
+        var player = CreatePlayer();
+
+        var result = await parser.ParseAsync(player, "  sAy   spaced   words   ");
+
+        var command = Assert.IsType<StubCommand>(result);
+        Assert.Equal("spaced words", command.Args);
+        Assert.Equal(player, definition.LastPlayer);
+        Assert.Equal("spaced words", definition.LastArgs);
+    }
+
+    private static Player CreatePlayer()
+    {
+        return new Player
+        {
+            Username = "Player",
+            Connection = new TestPlayerConnection()
+        };
+    }
+}

--- a/MooSharp.Tests/TestDoubles.cs
+++ b/MooSharp.Tests/TestDoubles.cs
@@ -1,0 +1,53 @@
+using MooSharp;
+using MooSharp.Messaging;
+
+namespace MooSharp.Tests;
+
+public sealed class RecordingDefinition : ICommandDefinition
+{
+    public RecordingDefinition(params string[] verbs)
+    {
+        Verbs = verbs;
+    }
+
+    public IReadOnlyCollection<string> Verbs { get; }
+
+    public string Description => "test";
+
+    public Player? LastPlayer { get; private set; }
+
+    public string? LastArgs { get; private set; }
+
+    public ICommand Create(Player player, string args)
+    {
+        LastPlayer = player;
+        LastArgs = args;
+        return new StubCommand(args);
+    }
+}
+
+public sealed class StubCommand : ICommand
+{
+    public StubCommand(string args)
+    {
+        Args = args;
+    }
+
+    public string Args { get; }
+
+    public Task<CommandResult> Dispatch(CommandExecutor executor, CancellationToken token)
+        => Task.FromResult(new CommandResult());
+}
+
+public sealed class TestPlayerConnection : IPlayerConnection
+{
+    public string Id { get; } = Guid.NewGuid().ToString();
+
+    public List<string> Messages { get; } = new();
+
+    public Task SendMessageAsync(string message)
+    {
+        Messages.Add(message);
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- share reusable test doubles for command definitions, commands, and player connections across test classes
- update CommandParser tests to rely on shared helpers and NullLogger without log assertions
- switch CommandHandler tests to the shared connection while preserving player creation helpers

## Testing
- dotnet test *(fails: CommandHandlerTests.DigHandler_RejectsDuplicateExitSlugAcrossWorld expects SystemMessageEvent vs RoomAlreadyExistsEvent)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a92d416c8331b027011c41b67e14)