### PR TITLE
Enhance homepage UI and expose player count

### DIFF
--- a/MooSharp.Web/Components/Pages/Home.razor
+++ b/MooSharp.Web/Components/Pages/Home.razor
@@ -1,7 +1,131 @@
-﻿@page "/"
+@page "/"
+@rendermode InteractiveServer
+@using System.Net.Http.Json
+@implements IAsyncDisposable
+@inject IHttpClientFactory HttpClientFactory
+@inject NavigationManager Navigation
 
 <PageTitle>Home</PageTitle>
 
-<h1>Hello, world!</h1>
+<div class="home-page">
+    <section class="hero">
+        <div class="hero__content">
+            <p class="eyebrow">Welcome to MooSharp</p>
+            <h1>Step into a living, text-driven world.</h1>
+            <p class="lede">
+                Explore rooms, meet other players, and uncover the secrets of the realm—all from your terminal-style command
+                line. Log in, register, and start adventuring in moments.
+            </p>
+            <div class="hero__actions">
+                <button class="primary" @onclick="NavigateToGame">Play the game</button>
+                <a class="ghost" href="/game">See the interface</a>
+            </div>
+            <div class="stat-card">
+                <p class="stat-label">Players online right now</p>
+                <p class="stat-value">@(_playerCount?.ToString() ?? "—")</p>
+                <p class="stat-hint">@_statusMessage</p>
+            </div>
+        </div>
+        <div class="hero__panel">
+            <div class="panel__header">Why MooSharp?</div>
+            <ul class="panel__list">
+                <li>
+                    <strong>Persistent characters</strong>
+                    <span>Pick up where you left off with session-based reconnects.</span>
+                </li>
+                <li>
+                    <strong>Realtime multiplayer</strong>
+                    <span>Chat with others and explore together in a shared world.</span>
+                </li>
+                <li>
+                    <strong>Agent-powered world</strong>
+                    <span>Background agents keep the realm lively even when you're away.</span>
+                </li>
+            </ul>
+        </div>
+    </section>
 
-Welcome to your new app.
+    <section class="info-grid">
+        <div class="info-card">
+            <p class="eyebrow">Get started fast</p>
+            <h2>Jump straight into the adventure</h2>
+            <p>
+                Head to the game page, choose a username and password, and you're ready to explore. Your commands, inventory,
+                and discoveries all persist between sessions.
+            </p>
+            <a class="inline-link" href="/game">Go to the game page →</a>
+        </div>
+        <div class="info-card">
+            <p class="eyebrow">Live activity</p>
+            <h2>See who's online</h2>
+            <button class="secondary" @onclick="NavigateToGame">Start playing</button>
+        </div>
+    </section>
+</div>
+
+@code {
+    private int? _playerCount;
+    private string _statusMessage = "Loading...";
+    private CancellationTokenSource? _pollingCts;
+    private static readonly TimeSpan PlayerCountInterval = TimeSpan.FromSeconds(5);
+
+    protected override async Task OnInitializedAsync()
+    {
+        _pollingCts = new CancellationTokenSource();
+
+        await RefreshPlayerCountAsync(_pollingCts.Token);
+        _ = PollPlayerCountAsync(_pollingCts.Token);
+    }
+
+    private async Task RefreshPlayerCountAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var client = HttpClientFactory.CreateClient();
+
+            client.BaseAddress ??= new Uri(Navigation.BaseUri);
+
+            var response = await client.GetFromJsonAsync<PlayerCountResponse>("api/player-count", cancellationToken);
+
+            _playerCount = response?.Count ?? 0;
+            _statusMessage = "Live players connected";
+        }
+        catch (OperationCanceledException)
+        {
+            // Ignore cancellations during disposal.
+        }
+        catch (Exception)
+        {
+            _statusMessage = "Unable to load player count right now.";
+        }
+    }
+
+    private async Task PollPlayerCountAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(PlayerCountInterval, cancellationToken);
+                await RefreshPlayerCountAsync(cancellationToken);
+                await InvokeAsync(StateHasChanged);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected during teardown.
+        }
+    }
+
+    private void NavigateToGame() => Navigation.NavigateTo("/game");
+
+    public ValueTask DisposeAsync()
+    {
+        _pollingCts?.Cancel();
+        _pollingCts?.Dispose();
+
+        return ValueTask.CompletedTask;
+    }
+
+    private sealed record PlayerCountResponse(int Count);
+}

--- a/MooSharp.Web/Endpoints/PlayerCountEndpoint.cs
+++ b/MooSharp.Web/Endpoints/PlayerCountEndpoint.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using MooSharp;
+
+namespace MooSharp.Web.Endpoints;
+
+public static class PlayerCountEndpoint
+{
+    public static IEndpointRouteBuilder MapPlayerCountEndpoint(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/player-count", (World world) => Results.Ok(new PlayerCountResponse(world.Players.Count)))
+            .WithName("GetPlayerCount");
+
+        return app;
+    }
+
+    private sealed record PlayerCountResponse(int Count);
+}

--- a/MooSharp.Web/GameEngine.cs
+++ b/MooSharp.Web/GameEngine.cs
@@ -106,7 +106,7 @@ public class GameEngine(
         await playerStore.SavePlayer(player, location);
         world.RemovePlayer(player);
 
-        world.Players.Remove(connectionId.Value);
+        world.Players.TryRemove(connectionId.Value, out _);
 
         if (sessionToken is not null)
         {
@@ -144,7 +144,7 @@ public class GameEngine(
 
         if (!string.IsNullOrEmpty(oldConnectionId))
         {
-            world.Players.Remove(oldConnectionId);
+            world.Players.TryRemove(oldConnectionId, out _);
         }
 
         player.Connection = new SignalRPlayerConnection(newConnectionId, hubContext);
@@ -242,7 +242,7 @@ public class GameEngine(
 
         await playerStore.SaveNewPlayer(player, defaultRoom, rc.Password);
 
-        world.Players.Add(connectionId.Value, player);
+        world.Players[connectionId.Value] = player;
         TrackSession(sessionToken, player, connectionId);
 
         var description = BuildCurrentRoomDescription(player);
@@ -295,7 +295,7 @@ public class GameEngine(
 
         world.MovePlayer(player, startingRoom);
 
-        world.Players.Add(connectionId.Value, player);
+        world.Players[connectionId.Value] = player;
         TrackSession(sessionToken, player, connectionId);
 
         var description = BuildCurrentRoomDescription(player);
@@ -379,7 +379,7 @@ public class GameEngine(
 
         world.MovePlayer(player, defaultRoom);
 
-        world.Players.Add(connectionId.Value, player);
+        world.Players[connectionId.Value] = player;
 
         logger.LogInformation("Agent {AgentName} registered", player.Username);
 

--- a/MooSharp.Web/Program.cs
+++ b/MooSharp.Web/Program.cs
@@ -6,11 +6,13 @@ using MooSharp.Agents;
 using MooSharp.Persistence;
 using MooSharp.Web;
 using MooSharp.Web.Components;
+using MooSharp.Web.Endpoints;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorComponents().AddInteractiveServerComponents();
 builder.Services.AddSignalR();
+builder.Services.AddHttpClient();
 
 builder.Services.AddMooSharpServices(builder.Configuration);
 builder.Services.AddMooSharpOptions(builder.Configuration);
@@ -34,6 +36,8 @@ app.UseAntiforgery();
 
 app.MapStaticAssets();
 app.MapRazorComponents<App>().AddInteractiveServerRenderMode();
+
+app.MapPlayerCountEndpoint();
 
 app.MapHub<MooHub>("/moohub");
 

--- a/MooSharp.Web/wwwroot/app.css
+++ b/MooSharp.Web/wwwroot/app.css
@@ -1,17 +1,258 @@
+:root {
+    --bg: #0c0f17;
+    --panel: #121825;
+    --panel-strong: #161d2d;
+    --accent: #7cf2d4;
+    --muted: #9fb0d0;
+    --text: #e6edff;
+    --danger: #e50000;
+    --success: #26b050;
+    --border: #1f273a;
+    --shadow: 0 20px 70px rgba(0, 0, 0, 0.35);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: radial-gradient(circle at 20% 20%, rgba(124, 242, 212, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(97, 124, 255, 0.12), transparent 30%),
+    var(--bg);
+    color: var(--text);
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+a {
+    color: var(--accent);
+}
+
+button {
+    font: inherit;
+    cursor: pointer;
+}
+
+button:focus-visible,
+a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.home-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem 4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.hero {
+    background: linear-gradient(135deg, rgba(124, 242, 212, 0.05), rgba(124, 242, 212, 0)),
+    linear-gradient(320deg, rgba(97, 124, 255, 0.08), rgba(97, 124, 255, 0));
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    padding: 2.5rem;
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 2rem;
+    box-shadow: var(--shadow);
+}
+
+.hero__content h1 {
+    margin: 0.4rem 0 0.75rem;
+    font-size: clamp(2rem, 4vw, 2.75rem);
+    line-height: 1.2;
+}
+
+.hero__content .lede {
+    color: var(--muted);
+    max-width: 55ch;
+    margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--accent);
+    font-weight: 700;
+    font-size: 0.8rem;
+    margin: 0;
+}
+
+.hero__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.primary,
+.secondary,
+.ghost {
+    border: 1px solid transparent;
+    border-radius: 12px;
+    padding: 0.75rem 1.4rem;
+    font-weight: 700;
+    transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease, border-color 120ms ease;
+    text-decoration: none;
+}
+
+.primary {
+    background: linear-gradient(135deg, #7cf2d4, #79d7ff);
+    color: #0b1220;
+    box-shadow: 0 10px 40px rgba(124, 242, 212, 0.35);
+    border-color: rgba(124, 242, 212, 0.4);
+}
+
+.primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 50px rgba(124, 242, 212, 0.45);
+}
+
+.secondary {
+    background: transparent;
+    color: var(--text);
+    border-color: var(--border);
+}
+
+.ghost {
+    background: rgba(255, 255, 255, 0.03);
+    color: var(--text);
+    border-color: rgba(255, 255, 255, 0.05);
+}
+
+.ghost:hover,
+.secondary:hover {
+    border-color: rgba(124, 242, 212, 0.5);
+    transform: translateY(-1px);
+}
+
+.stat-card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 1rem 1.25rem;
+    width: fit-content;
+    min-width: 220px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.stat-label {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.stat-value {
+    margin: 0.25rem 0 0.15rem;
+    font-size: 2rem;
+    font-weight: 800;
+}
+
+.stat-hint {
+    margin: 0;
+    color: var(--muted);
+    font-size: 0.9rem;
+}
+
+.hero__panel {
+    background: var(--panel-strong);
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
+}
+
+.panel__header {
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.panel__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.panel__list li {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 0.9rem 1rem;
+}
+
+.panel__list strong {
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+.panel__list span {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.25rem;
+}
+
+.info-card {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    padding: 1.5rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+}
+
+.info-card h2 {
+    margin: 0.4rem 0 0.5rem;
+}
+
+.info-card p {
+    color: var(--muted);
+}
+
+.inline-link {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.inline-link:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+    .hero {
+        grid-template-columns: 1fr;
+    }
+
+    .hero__actions {
+        flex-wrap: wrap;
+    }
+}
+
 h1:focus {
     outline: none;
 }
 
 .valid.modified:not([type=checkbox]) {
-    outline: 1px solid #26b050;
+    outline: 1px solid var(--success);
 }
 
 .invalid {
-    outline: 1px solid #e50000;
+    outline: 1px solid var(--danger);
 }
 
 .validation-message {
-    color: #e50000;
+    color: var(--danger);
 }
 
 .blazor-error-boundary {
@@ -21,7 +262,7 @@ h1:focus {
 }
 
     .blazor-error-boundary::after {
-        content: "An error has occurred."
+        content: "An error has occurred.";
     }
 
 .darker-border-checkbox.form-check-input {
@@ -29,7 +270,7 @@ h1:focus {
 }
 
 .form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
-    color: var(--bs-secondary-color);
+    color: var(--muted);
     text-align: end;
 }
 

--- a/MooSharp/World.cs
+++ b/MooSharp/World.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using MooSharp.Persistence;
 using Microsoft.Extensions.Logging;
 
@@ -5,7 +6,7 @@ namespace MooSharp;
 
 public class World(IWorldStore worldStore, ILogger<World> logger)
 {
-    public Dictionary<string, Player> Players { get; } = [];
+    public ConcurrentDictionary<string, Player> Players { get; } = new();
     public IReadOnlyDictionary<RoomId, Room> Rooms => _rooms;
     private readonly Dictionary<RoomId, Room> _rooms = new();
 


### PR DESCRIPTION
## Summary
- refine homepage copy by removing SignalR mention and trimming the live activity explanation while keeping navigation to the game page
- move the player count API into a dedicated endpoint while counting from a thread-safe player dictionary
- update connection management to use concurrent player tracking for add/remove scenarios

## Testing
- `dotnet test` *(fails: CommandHandlerTests.DigHandler_RejectsDuplicateExitSlugAcrossWorld and CommandHandlerTests.DigHandler_CreatesRoomAndPersistsExits, plus MSBuild terminal logger error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925a83bbc2c8331b853ee0672d151c9)