### PR TITLE
Add world initialization service

### DIFF
--- a/MooSharp.Tests/CommandHandlerTests.cs
+++ b/MooSharp.Tests/CommandHandlerTests.cs
@@ -1,8 +1,7 @@
 using Microsoft.Extensions.Logging.Abstractions;
-using Microsoft.Extensions.Options;
 using MooSharp;
 using MooSharp.Messaging;
-using MooSharp.Persistence;
+using MooSharp.Tests.TestDoubles;
 
 namespace MooSharp.Tests;
 
@@ -346,33 +345,14 @@ public class CommandHandlerTests
         Assert.False(string.IsNullOrWhiteSpace(evt.Message));
     }
 
-    private static WorldFactory CreateWorldFactory(InMemoryWorldStore? store = null)
-    {
-        var options = Options.Create(new AppOptions
-        {
-            WorldDataFilepath = "world.json",
-            DatabaseFilepath = "game.db"
-        });
-
-        return new WorldFactory(options, NullLogger<WorldFactory>.Instance, store ?? new InMemoryWorldStore(),
-            NullLogger<World>.Instance);
-    }
-
-    private static Task<World> CreateWorld(params Room[] rooms) => CreateWorld(null, rooms);
-
-    private static async Task<World> CreateWorld(InMemoryWorldStore? store, params Room[] rooms)
-    {
-        var factory = CreateWorldFactory(store);
-
-        return await factory.CreateWorldAsync(rooms.ToList());
-    }
-
-    private static async Task<(World world, InMemoryWorldStore store)> CreateWorldWithStore(params Room[] rooms)
+    private static Task<World> CreateWorld(params Room[] rooms)
     {
         var store = new InMemoryWorldStore();
-        var world = await CreateWorld(store, rooms);
+        var world = new World(store, NullLogger<World>.Instance);
 
-        return (world, store);
+        world.Initialize(rooms);
+
+        return Task.FromResult(world);
     }
 
     private static Room CreateRoom(string slug)
@@ -395,85 +375,5 @@ public class CommandHandlerTests
             Username = username ?? "Player",
             Connection = new TestPlayerConnection()
         };
-    }
-
-    private sealed class InMemoryWorldStore : IWorldStore
-    {
-        private readonly List<Room> _rooms = new();
-        private readonly List<(RoomId From, RoomId To, string Direction)> _exits = new();
-
-        public Task<bool> HasRoomsAsync(CancellationToken cancellationToken = default)
-            => Task.FromResult(_rooms.Any());
-
-        public Task<IReadOnlyCollection<Room>> LoadRoomsAsync(CancellationToken cancellationToken = default)
-        {
-            var rooms = _rooms.Select(CloneRoom).ToList();
-
-            foreach (var exit in _exits)
-            {
-                var origin = rooms.SingleOrDefault(r => r.Id == exit.From);
-                if (origin is null)
-                {
-                    continue;
-                }
-
-                origin.Exits[exit.Direction] = exit.To;
-            }
-
-            return Task.FromResult<IReadOnlyCollection<Room>>(rooms);
-        }
-
-        public Task SaveRoomAsync(Room room, CancellationToken cancellationToken = default)
-        {
-            _rooms.RemoveAll(r => r.Id == room.Id);
-            _rooms.Add(CloneRoom(room));
-            return Task.CompletedTask;
-        }
-
-        public Task SaveExitAsync(RoomId fromRoomId, RoomId toRoomId, string direction,
-            CancellationToken cancellationToken = default)
-        {
-            _exits.RemoveAll(e => e.From == fromRoomId && string.Equals(e.Direction, direction, StringComparison.OrdinalIgnoreCase));
-            _exits.Add((fromRoomId, toRoomId, direction));
-            return Task.CompletedTask;
-        }
-
-        public Task SaveRoomsAsync(IEnumerable<Room> rooms, CancellationToken cancellationToken = default)
-        {
-            _rooms.Clear();
-            _rooms.AddRange(rooms.Select(CloneRoom));
-
-            _exits.Clear();
-
-            foreach (var room in rooms)
-            {
-                foreach (var exit in room.Exits)
-                {
-                    _exits.Add((room.Id, exit.Value, exit.Key));
-                }
-            }
-
-            return Task.CompletedTask;
-        }
-
-        private static Room CloneRoom(Room room)
-        {
-            var clone = new Room
-            {
-                Id = room.Id,
-                Name = room.Name,
-                Description = room.Description,
-                LongDescription = room.LongDescription,
-                EnterText = room.EnterText,
-                ExitText = room.ExitText
-            };
-
-            foreach (var exit in room.Exits)
-            {
-                clone.Exits[exit.Key] = exit.Value;
-            }
-
-            return clone;
-        }
     }
 }

--- a/MooSharp.Tests/TestDoubles/InMemoryWorldStore.cs
+++ b/MooSharp.Tests/TestDoubles/InMemoryWorldStore.cs
@@ -1,0 +1,84 @@
+using MooSharp;
+using MooSharp.Persistence;
+
+namespace MooSharp.Tests.TestDoubles;
+
+internal sealed class InMemoryWorldStore : IWorldStore
+{
+    private readonly List<Room> _rooms = new();
+    private readonly List<(RoomId From, RoomId To, string Direction)> _exits = new();
+
+    public Task<bool> HasRoomsAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(_rooms.Any());
+
+    public Task<IReadOnlyCollection<Room>> LoadRoomsAsync(CancellationToken cancellationToken = default)
+    {
+        var rooms = _rooms.Select(CloneRoom).ToList();
+
+        foreach (var exit in _exits)
+        {
+            var origin = rooms.SingleOrDefault(r => r.Id == exit.From);
+            if (origin is null)
+            {
+                continue;
+            }
+
+            origin.Exits[exit.Direction] = exit.To;
+        }
+
+        return Task.FromResult<IReadOnlyCollection<Room>>(rooms);
+    }
+
+    public Task SaveRoomAsync(Room room, CancellationToken cancellationToken = default)
+    {
+        _rooms.RemoveAll(r => r.Id == room.Id);
+        _rooms.Add(CloneRoom(room));
+        return Task.CompletedTask;
+    }
+
+    public Task SaveExitAsync(RoomId fromRoomId, RoomId toRoomId, string direction,
+        CancellationToken cancellationToken = default)
+    {
+        _exits.RemoveAll(e => e.From == fromRoomId && string.Equals(e.Direction, direction, StringComparison.OrdinalIgnoreCase));
+        _exits.Add((fromRoomId, toRoomId, direction));
+        return Task.CompletedTask;
+    }
+
+    public Task SaveRoomsAsync(IEnumerable<Room> rooms, CancellationToken cancellationToken = default)
+    {
+        _rooms.Clear();
+        _rooms.AddRange(rooms.Select(CloneRoom));
+
+        _exits.Clear();
+
+        foreach (var room in rooms)
+        {
+            foreach (var exit in room.Exits)
+            {
+                _exits.Add((room.Id, exit.Value, exit.Key));
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Room CloneRoom(Room room)
+    {
+        var clone = new Room
+        {
+            Id = room.Id,
+            Name = room.Name,
+            Description = room.Description,
+            LongDescription = room.LongDescription,
+            EnterText = room.EnterText,
+            ExitText = room.ExitText
+        };
+
+        foreach (var exit in room.Exits)
+        {
+            clone.Exits[exit.Key] = exit.Value;
+        }
+
+        return clone;
+    }
+}

--- a/MooSharp.Tests/WorldInitializerTests.cs
+++ b/MooSharp.Tests/WorldInitializerTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using MooSharp.Tests.TestDoubles;
+
+namespace MooSharp.Tests;
+
+public class WorldInitializerTests
+{
+    [Fact]
+    public async Task InitializeAsync_LoadsExistingRooms()
+    {
+        var store = new InMemoryWorldStore();
+        var existingRoom = CreateRoom("existing");
+        await store.SaveRoomsAsync([existingRoom]);
+
+        var seeder = new TestWorldSeeder([CreateRoom("seed")]);
+        var world = new World(store, NullLogger<World>.Instance);
+        var initializer = new WorldInitializer(world, store, seeder, NullLogger<WorldInitializer>.Instance);
+
+        await initializer.InitializeAsync();
+
+        Assert.Equal(existingRoom.Id, Assert.Single(world.Rooms).Key);
+        Assert.False(seeder.WasCalled);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_SeedsAndPersistsWhenStoreEmpty()
+    {
+        var store = new InMemoryWorldStore();
+        var seedRoom = CreateRoom("seed");
+        var seeder = new TestWorldSeeder([seedRoom]);
+        var world = new World(store, NullLogger<World>.Instance);
+        var initializer = new WorldInitializer(world, store, seeder, NullLogger<WorldInitializer>.Instance);
+
+        await initializer.InitializeAsync();
+
+        var room = Assert.Single(world.Rooms).Value;
+        Assert.Equal(seedRoom.Id, room.Id);
+        Assert.True(seeder.WasCalled);
+
+        var persisted = await store.LoadRoomsAsync();
+        Assert.Equal(seedRoom.Id, Assert.Single(persisted).Id);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_WithProvidedRoomsPersists()
+    {
+        var store = new InMemoryWorldStore();
+        var providedRoom = CreateRoom("provided");
+        var seeder = new TestWorldSeeder(Array.Empty<Room>());
+        var world = new World(store, NullLogger<World>.Instance);
+        var initializer = new WorldInitializer(world, store, seeder, NullLogger<WorldInitializer>.Instance);
+
+        await initializer.InitializeAsync([providedRoom]);
+
+        Assert.Equal(providedRoom.Id, Assert.Single(world.Rooms).Key);
+
+        var persisted = await store.LoadRoomsAsync();
+        Assert.Equal(providedRoom.Id, Assert.Single(persisted).Id);
+    }
+
+    private static Room CreateRoom(string slug)
+    {
+        return new Room
+        {
+            Id = slug,
+            Name = $"{slug} name",
+            Description = $"{slug} description",
+            LongDescription = $"{slug} long description",
+            EnterText = string.Empty,
+            ExitText = string.Empty
+        };
+    }
+
+    private sealed class TestWorldSeeder(IReadOnlyCollection<Room> rooms) : IWorldSeeder
+    {
+        public bool WasCalled { get; private set; }
+
+        public IReadOnlyCollection<Room> GetSeedRooms()
+        {
+            WasCalled = true;
+            return rooms;
+        }
+    }
+}

--- a/MooSharp.Web/Program.cs
+++ b/MooSharp.Web/Program.cs
@@ -1,9 +1,5 @@
-using System.Reflection;
-using System.Threading.Channels;
-using Microsoft.SemanticKernel;
+using Microsoft.Extensions.DependencyInjection;
 using MooSharp;
-using MooSharp.Agents;
-using MooSharp.Persistence;
 using MooSharp.Web;
 using MooSharp.Web.Components;
 using MooSharp.Web.Endpoints;
@@ -25,6 +21,8 @@ builder.RegisterPresenters();
 
 var app = builder.Build();
 
+await InitializeWorldAsync(app.Services);
+
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
@@ -42,4 +40,12 @@ app.MapPlayerCountEndpoint();
 app.MapHub<MooHub>("/moohub");
 
 await app.RunAsync();
+
+static async Task InitializeWorldAsync(IServiceProvider serviceProvider)
+{
+    using var scope = serviceProvider.CreateScope();
+    var initializer = scope.ServiceProvider.GetRequiredService<WorldInitializer>();
+
+    await initializer.InitializeAsync();
+}
 

--- a/MooSharp.Web/ServiceCollectionExtensions.cs
+++ b/MooSharp.Web/ServiceCollectionExtensions.cs
@@ -10,13 +10,9 @@ public static class ServiceCollectionExtensions
 {
     public static void AddMooSharpServices(this IServiceCollection services, IConfiguration config)
     {
-        services.AddSingleton<WorldFactory>();
-        services.AddSingleton(sp =>
-        {
-            var factory = sp.GetRequiredService<WorldFactory>();
-
-            return factory.CreateWorldAsync().Result;
-        });
+        services.AddSingleton<IWorldSeeder, WorldSeeder>();
+        services.AddSingleton<WorldInitializer>();
+        services.AddSingleton<World>();
         services.AddSingleton<CommandParser>();
         services.AddSingleton<CommandExecutor>();
         services.AddSingleton<CommandReference>();

--- a/MooSharp/World.cs
+++ b/MooSharp/World.cs
@@ -17,6 +17,7 @@ public class World(IWorldStore worldStore, ILogger<World> logger)
         ArgumentNullException.ThrowIfNull(rooms);
 
         _rooms.Clear();
+        _playerLocations.Clear();
 
         foreach (var room in rooms)
         {


### PR DESCRIPTION
## Summary
- introduce an IWorldSeeder/WorldInitializer pair to load or seed the world asynchronously
- register the world as a singleton and initialize it before the host starts
- add an in-memory world store test double and unit tests covering initialization flows

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925b1e9a17c833183f056f7728a8bc4)