### PR TITLE
Apply terminal-style aesthetic to web UI

### DIFF
--- a/MooSharp.Web/Components/Pages/Game.razor
+++ b/MooSharp.Web/Components/Pages/Game.razor
@@ -7,49 +7,65 @@
 @implements IAsyncDisposable
 @rendermode InteractiveServer
 
-<h3>MooSharp</h3>
-
 @if (_hubConnection is null || _hubConnection.State != HubConnectionState.Connected)
 {
-    <p><em>Connecting to server...</em></p>
+    <div class="page-shell">
+        <div class="terminal-card" data-label="/status">
+            <p class="tag">connecting</p>
+            <p><em>Establishing SignalR connection...</em></p>
+        </div>
+    </div>
 }
 else
 {
-    <div class="auth-container">
-        <h4>Register or Log In</h4>
-        <div class="auth-fields">
-            <input @bind="_username" placeholder="Username" />
-            <input type="password" @bind="_password" placeholder="Password" />
+    <div class="page-shell game-shell">
+        <div class="game-header">
+            <div>
+                <p class="tag">/game</p>
+                <h2 class="panel-heading">MooSharp terminal client</h2>
+            </div>
+            <span class="status-message">@(_isLoggedIn ? "Session active" : "Awaiting authentication")</span>
         </div>
-        <div class="auth-actions">
-            <button @onclick="LoginAsync" disabled="@(!CanSubmitCredentials)">Log In</button>
-            <button @onclick="RegisterAsync" disabled="@(!CanSubmitCredentials)">Register</button>
-            <button @onclick="LogoutAsync" disabled="@(!_isLoggedIn)">Log Out</button>
+
+        <div class="game-grid">
+            <div class="terminal-card auth-panel" data-label="/auth">
+                <h2 class="panel-heading">Credentials</h2>
+                <input @bind="_username" placeholder="Username" />
+                <input type="password" @bind="_password" placeholder="Password" />
+                <div class="auth-actions">
+                    <button class="btn btn-accent" @onclick="LoginAsync" disabled="@(!CanSubmitCredentials)">Log In</button>
+                    <button class="btn btn-ghost" @onclick="RegisterAsync" disabled="@(!CanSubmitCredentials)">Register</button>
+                    <button class="btn" @onclick="LogoutAsync" disabled="@(!_isLoggedIn)">Log Out</button>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(_loginStatus))
+                {
+                    <p class="status-message">@_loginStatus</p>
+                }
+            </div>
+
+            <fieldset disabled="@(!_isLoggedIn)">
+                <div class="terminal-card" data-label="/world-feed">
+                    <h2 class="panel-heading">World output</h2>
+                    <pre class="terminal-output">@_gameOutput</pre>
+
+                    <div class="command-input">
+                        <input @bind="_commandInput"
+                               @bind:event="oninput"
+                               @onkeydown="HandleKeyDown"
+                               placeholder="Type a command..." />
+                        <div class="command-actions">
+                            <button class="btn btn-accent" @onclick="SendCommandAsync">Send</button>
+                        </div>
+                    </div>
+
+                    @if (!_isLoggedIn)
+                    {
+                        <p class="status-message">Log in or register to start playing.</p>
+                    }
+                </div>
+            </fieldset>
         </div>
-        @if (!string.IsNullOrWhiteSpace(_loginStatus))
-        {
-            <p class="status-message">@_loginStatus</p>
-        }
     </div>
-
-    <fieldset disabled="@(!_isLoggedIn)">
-        <div class="game-output-container">
-            <pre>@_gameOutput</pre>
-        </div>
-
-        <div class="input-container">
-            <input @bind="_commandInput"
-                   @bind:event="oninput"
-                   @onkeydown="HandleKeyDown"
-                   placeholder="Type a command..." />
-            <button @onclick="SendCommandAsync">Send</button>
-        </div>
-
-        @if (!_isLoggedIn)
-        {
-            <p class="status-message">Log in or register to start playing.</p>
-        }
-    </fieldset>
 }
 
 @code {

--- a/MooSharp.Web/Components/Pages/Home.razor
+++ b/MooSharp.Web/Components/Pages/Home.razor
@@ -7,60 +7,60 @@
 
 <PageTitle>Home</PageTitle>
 
-<div class="home-page">
-    <section class="hero">
-        <div class="hero__content">
-            <p class="eyebrow">Welcome to MooSharp</p>
-            <h1>Step into a living, text-driven world.</h1>
+<div class="page-shell">
+    <div class="terminal-hero">
+        <div class="terminal-card" data-label="/landing">
+            <p class="tag">welcome</p>
+            <h1 class="hero-title">MooSharp is a living terminal world.</h1>
             <p class="lede">
-                Explore rooms, meet other players, and uncover the secrets of the realm—all from your terminal-style command
-                line. Log in, register, and start adventuring in moments.
+                Connect, register, and roam a multiplayer text realm. Keep your session alive, chat with others, and let the
+                agents keep the world humming even when you're offline.
             </p>
-            <div class="hero__actions">
-                <button class="primary" @onclick="NavigateToGame">Play the game</button>
-                <a class="ghost" href="/game">See the interface</a>
+            <div class="actions">
+                <button class="btn btn-accent" @onclick="NavigateToGame">Launch client</button>
+                <a class="btn btn-ghost" href="/game">Preview interface</a>
             </div>
-            <div class="stat-card">
-                <p class="stat-label">Players online right now</p>
-                <p class="stat-value">@(_playerCount?.ToString() ?? "—")</p>
-                <p class="stat-hint">@_statusMessage</p>
+            <div class="stat-line">
+                <span>Players online: @_playerCount?.ToString() ?? "—"</span>
+                <span>@_statusMessage</span>
             </div>
         </div>
-        <div class="hero__panel">
-            <div class="panel__header">Why MooSharp?</div>
-            <ul class="panel__list">
+
+        <div class="terminal-card" data-label="/system-log">
+            <ul class="list-reset">
                 <li>
-                    <strong>Persistent characters</strong>
-                    <span>Pick up where you left off with session-based reconnects.</span>
+                    <strong>Persistent sessions</strong>
+                    <span>Reconnect with your stored session ID and pick up right where you left off.</span>
                 </li>
                 <li>
-                    <strong>Realtime multiplayer</strong>
-                    <span>Chat with others and explore together in a shared world.</span>
+                    <strong>Realtime SignalR</strong>
+                    <span>Chat, explore, and receive updates instantly through the hub.</span>
                 </li>
                 <li>
-                    <strong>Agent-powered world</strong>
-                    <span>Background agents keep the realm lively even when you're away.</span>
+                    <strong>Agents in the loop</strong>
+                    <span>Background agents keep the world reactive without manual babysitting.</span>
                 </li>
             </ul>
         </div>
-    </section>
+    </div>
 
-    <section class="info-grid">
+    <div class="info-grid">
         <div class="info-card">
-            <p class="eyebrow">Get started fast</p>
-            <h2>Jump straight into the adventure</h2>
+            <p class="tag">quickstart</p>
+            <h2>Join a room in seconds</h2>
             <p>
-                Head to the game page, choose a username and password, and you're ready to explore. Your commands, inventory,
-                and discoveries all persist between sessions.
+                Head to the game page, choose a username and password, then issue commands. Your inventory and discoveries
+                persist between logins.
             </p>
-            <a class="inline-link" href="/game">Go to the game page →</a>
+            <a class="inline-link" href="/game">Open the /game terminal →</a>
         </div>
         <div class="info-card">
-            <p class="eyebrow">Live activity</p>
-            <h2>See who's online</h2>
-            <button class="secondary" @onclick="NavigateToGame">Start playing</button>
+            <p class="tag">activity</p>
+            <h2>Who's online?</h2>
+            <p>Check the live connection count, then step in to say hello.</p>
+            <button class="btn btn-ghost" @onclick="NavigateToGame">Start playing</button>
         </div>
-    </section>
+    </div>
 </div>
 
 @code {

--- a/MooSharp.Web/wwwroot/app.css
+++ b/MooSharp.Web/wwwroot/app.css
@@ -1,14 +1,14 @@
 :root {
-    --bg: #0c0f17;
-    --panel: #121825;
-    --panel-strong: #161d2d;
-    --accent: #7cf2d4;
-    --muted: #9fb0d0;
-    --text: #e6edff;
-    --danger: #e50000;
-    --success: #26b050;
-    --border: #1f273a;
-    --shadow: 0 20px 70px rgba(0, 0, 0, 0.35);
+    --bg: #0a0a0a;
+    --panel: #0f0f0f;
+    --ink: #f5f5f5;
+    --muted: #b5b5b5;
+    --accent: #7df19d;
+    --border: #1d1d1d;
+    --border-strong: #ffffff;
+    --danger: #ff5b5b;
+    --success: #9cff9c;
+    --shadow: 0 0 0 2px var(--border), 8px 8px 0 0 #000000;
 }
 
 * {
@@ -17,16 +17,20 @@
 
 body {
     margin: 0;
-    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    background: radial-gradient(circle at 20% 20%, rgba(124, 242, 212, 0.08), transparent 35%),
-    radial-gradient(circle at 80% 0%, rgba(97, 124, 255, 0.12), transparent 30%),
+    font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+    background: radial-gradient(circle at 10% 20%, rgba(255, 255, 255, 0.04), transparent 30%),
+    radial-gradient(circle at 90% 0%, rgba(255, 255, 255, 0.06), transparent 25%),
     var(--bg);
-    color: var(--text);
+    color: var(--ink);
     min-height: 100vh;
-    line-height: 1.6;
+    letter-spacing: 0.01em;
 }
 
 a {
+    color: inherit;
+}
+
+a:hover {
     color: var(--accent);
 }
 
@@ -36,183 +40,161 @@ button {
 }
 
 button:focus-visible,
-a:focus-visible {
-    outline: 2px solid var(--accent);
+a:focus-visible,
+input:focus-visible {
+    outline: 2px solid var(--border-strong);
     outline-offset: 2px;
 }
 
-.home-page {
-    max-width: 1200px;
+.page-shell {
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 3rem 1.5rem 4rem;
+    padding: 2.5rem 1.5rem 4rem;
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1.5rem;
 }
 
-.hero {
-    background: linear-gradient(135deg, rgba(124, 242, 212, 0.05), rgba(124, 242, 212, 0)),
-    linear-gradient(320deg, rgba(97, 124, 255, 0.08), rgba(97, 124, 255, 0));
-    border: 1px solid var(--border);
-    border-radius: 18px;
-    padding: 2.5rem;
+.terminal-hero {
     display: grid;
-    grid-template-columns: 1.1fr 0.9fr;
-    gap: 2rem;
-    box-shadow: var(--shadow);
+    grid-template-columns: 1.15fr 0.85fr;
+    gap: 1.5rem;
 }
 
-.hero__content h1 {
-    margin: 0.4rem 0 0.75rem;
-    font-size: clamp(2rem, 4vw, 2.75rem);
+.terminal-card {
+    background: var(--panel);
+    border: 2px solid var(--border-strong);
+    box-shadow: var(--shadow);
+    padding: 1.5rem;
+    position: relative;
+}
+
+.terminal-card::before {
+    content: attr(data-label);
+    position: absolute;
+    top: -0.9rem;
+    left: 0.75rem;
+    background: var(--bg);
+    color: var(--ink);
+    padding: 0.15rem 0.5rem;
+    border: 2px solid var(--border-strong);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.75rem;
+}
+
+.tag {
+    display: inline-block;
+    background: var(--ink);
+    color: var(--bg);
+    padding: 0.25rem 0.6rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    border: 2px solid var(--border-strong);
+}
+
+.hero-title {
+    margin: 0.8rem 0 0.5rem;
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
     line-height: 1.2;
 }
 
-.hero__content .lede {
+.lede {
     color: var(--muted);
-    max-width: 55ch;
-    margin-bottom: 1.5rem;
+    max-width: 60ch;
+    margin-bottom: 1.2rem;
 }
 
-.eyebrow {
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--accent);
-    font-weight: 700;
-    font-size: 0.8rem;
-    margin: 0;
-}
-
-.hero__actions {
+.actions {
     display: flex;
-    align-items: center;
     gap: 0.75rem;
-    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
 }
 
-.primary,
-.secondary,
-.ghost {
-    border: 1px solid transparent;
-    border-radius: 12px;
-    padding: 0.75rem 1.4rem;
-    font-weight: 700;
-    transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease, border-color 120ms ease;
+.btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.7rem 1.1rem;
+    border: 2px solid var(--border-strong);
+    background: var(--bg);
+    color: var(--ink);
     text-decoration: none;
+    font-weight: 700;
+    text-transform: uppercase;
+    box-shadow: 4px 4px 0 0 #000000;
+    transition: transform 80ms ease, box-shadow 80ms ease, background 120ms ease;
 }
 
-.primary {
-    background: linear-gradient(135deg, #7cf2d4, #79d7ff);
-    color: #0b1220;
-    box-shadow: 0 10px 40px rgba(124, 242, 212, 0.35);
-    border-color: rgba(124, 242, 212, 0.4);
+.btn:hover {
+    transform: translate(-2px, -2px);
+    box-shadow: 7px 7px 0 0 #000000;
 }
 
-.primary:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 12px 50px rgba(124, 242, 212, 0.45);
+.btn-accent {
+    background: var(--accent);
+    color: #071107;
 }
 
-.secondary {
-    background: transparent;
-    color: var(--text);
-    border-color: var(--border);
-}
-
-.ghost {
-    background: rgba(255, 255, 255, 0.03);
-    color: var(--text);
-    border-color: rgba(255, 255, 255, 0.05);
-}
-
-.ghost:hover,
-.secondary:hover {
-    border-color: rgba(124, 242, 212, 0.5);
-    transform: translateY(-1px);
-}
-
-.stat-card {
+.btn-ghost {
     background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 1rem 1.25rem;
-    width: fit-content;
-    min-width: 220px;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
 }
 
-.stat-label {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.9rem;
+.stat-line {
+    margin-top: 1rem;
+    padding: 0.9rem 1rem;
+    border: 2px dashed var(--border-strong);
+    background: #0b0b0b;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.5rem;
+    font-weight: 700;
 }
 
-.stat-value {
-    margin: 0.25rem 0 0.15rem;
-    font-size: 2rem;
-    font-weight: 800;
+.stat-line span {
+    display: block;
 }
 
-.stat-hint {
-    margin: 0;
-    color: var(--muted);
-    font-size: 0.9rem;
-}
-
-.hero__panel {
-    background: var(--panel-strong);
-    border: 1px solid var(--border);
-    border-radius: 16px;
-    padding: 1.5rem;
-    box-shadow: 0 10px 40px rgba(0, 0, 0, 0.25);
-}
-
-.panel__header {
-    font-weight: 800;
-    margin-bottom: 1rem;
-}
-
-.panel__list {
+.list-reset {
     list-style: none;
     padding: 0;
     margin: 0;
     display: grid;
-    gap: 1rem;
+    gap: 0.85rem;
 }
 
-.panel__list li {
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 0.9rem 1rem;
+.list-reset li {
+    border: 2px solid var(--border);
+    padding: 0.8rem 0.9rem;
+    background: #050505;
 }
 
-.panel__list strong {
+.list-reset strong {
     display: block;
-    margin-bottom: 0.25rem;
+    margin-bottom: 0.2rem;
 }
 
-.panel__list span {
+.list-reset span {
     color: var(--muted);
     font-size: 0.95rem;
 }
 
 .info-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 1.25rem;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1rem;
 }
 
 .info-card {
+    border: 2px solid var(--border-strong);
+    box-shadow: var(--shadow);
     background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: 14px;
-    padding: 1.5rem;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    padding: 1.2rem 1.3rem;
 }
 
 .info-card h2 {
-    margin: 0.4rem 0 0.5rem;
+    margin: 0.6rem 0 0.3rem;
 }
 
 .info-card p {
@@ -220,27 +202,85 @@ a:focus-visible {
 }
 
 .inline-link {
-    color: var(--accent);
     text-decoration: none;
+    border-bottom: 2px solid var(--ink);
+    padding-bottom: 0.1rem;
     font-weight: 700;
 }
 
 .inline-link:hover {
-    text-decoration: underline;
+    color: var(--accent);
+    border-color: var(--accent);
 }
 
-@media (max-width: 900px) {
-    .hero {
-        grid-template-columns: 1fr;
-    }
-
-    .hero__actions {
-        flex-wrap: wrap;
-    }
+.game-shell {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
 
-h1:focus {
-    outline: none;
+.game-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border: 2px solid var(--border-strong);
+    padding: 0.8rem 1rem;
+    background: #0d0d0d;
+    box-shadow: var(--shadow);
+}
+
+.game-grid {
+    display: grid;
+    grid-template-columns: 0.9fr 1.1fr;
+    gap: 1rem;
+}
+
+.panel-heading {
+    margin: 0 0 0.5rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.auth-panel input,
+.command-input input {
+    width: 100%;
+    padding: 0.7rem 0.8rem;
+    border: 2px solid var(--border-strong);
+    background: var(--bg);
+    color: var(--ink);
+    margin-bottom: 0.6rem;
+}
+
+.auth-actions,
+.command-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.terminal-output {
+    background: #050505;
+    border: 2px solid var(--border-strong);
+    padding: 1rem;
+    height: 360px;
+    overflow-y: auto;
+    font-size: 0.95rem;
+    line-height: 1.4;
+}
+
+.status-message {
+    margin: 0.4rem 0 0;
+    color: var(--muted);
+}
+
+fieldset {
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
+fieldset:disabled {
+    opacity: 0.6;
 }
 
 .valid.modified:not([type=checkbox]) {
@@ -256,24 +296,23 @@ h1:focus {
 }
 
 .blazor-error-boundary {
-    background: url(data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNDkiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIG92ZXJmbG93PSJoaWRkZW4iPjxkZWZzPjxjbGlwUGF0aCBpZD0iY2xpcDAiPjxyZWN0IHg9IjIzNSIgeT0iNTEiIHdpZHRoPSI1NiIgaGVpZ2h0PSI0OSIvPjwvY2xpcFBhdGg+PC9kZWZzPjxnIGNsaXAtcGF0aD0idXJsKCNjbGlwMCkiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMzUgLTUxKSI+PHBhdGggZD0iTTI2My41MDYgNTFDMjY0LjcxNyA1MSAyNjUuODEzIDUxLjQ4MzcgMjY2LjYwNiA1Mi4yNjU4TDI2Ny4wNTIgNTIuNzk4NyAyNjcuNTM5IDUzLjYyODMgMjkwLjE4NSA5Mi4xODMxIDI5MC41NDUgOTIuNzk1IDI5MC42NTYgOTIuOTk2QzI5MC44NzcgOTMuNTEzIDI5MSA5NC4wODE1IDI5MSA5NC42NzgyIDI5MSA5Ny4wNjUxIDI4OS4wMzggOTkgMjg2LjYxNyA5OUwyNDAuMzgzIDk5QzIzNy45NjMgOTkgMjM2IDk3LjA2NTEgMjM2IDk0LjY3ODIgMjM2IDk0LjM3OTkgMjM2LjAzMSA5NC4wODg2IDIzNi4wODkgOTMuODA3MkwyMzYuMzM4IDkzLjAxNjIgMjM2Ljg1OCA5Mi4xMzE0IDI1OS40NzMgNTMuNjI5NCAyNTkuOTYxIDUyLjc5ODUgMjYwLjQwNyA1Mi4yNjU4QzI2MS4yIDUxLjQ4MzcgMjYyLjI5NiA1MSAyNjMuNTA2IDUxWk0yNjMuNTg2IDY2LjAxODNDMjYwLjczNyA2Ni4wMTgzIDI1OS4zMTMgNjcuMTI0NSAyNTkuMzEzIDY5LjMzNyAyNTkuMzEzIDY5LjYxMDIgMjU5LjMzMiA2OS44NjA4IDI1OS4zNzEgNzAuMDg4N0wyNjEuNzk1IDg0LjAxNjEgMjY1LjM4IDg0LjAxNjEgMjY3LjgyMSA2OS43NDc1QzI2Ny44NiA2OS43MzA5IDI2Ny44NzkgNjkuNTg3NyAyNjcuODc5IDY5LjMxNzkgMjY3Ljg3OSA2Ny4xMTgyIDI2Ni40NDggNjYuMDE4MyAyNjMuNTg2IDY2LjAxODNaTTI2My41NzYgODYuMDU0N0MyNjEuMDQ5IDg2LjA1NDcgMjU5Ljc4NiA4Ny4zMDA1IDI1OS43ODYgODkuNzkyMSAyNTkuNzg2IDkyLjI4MzcgMjYxLjA0OSA5My41Mjk1IDI2My41NzYgOTMuNTI5NSAyNjYuMTE2IDkzLjUyOTUgMjY3LjM4NyA5Mi4yODM3IDI2Ny4zODcgODkuNzkyMSAyNjcuMzg3IDg3LjMwMDUgMjY2LjExNiA4Ni4wNTQ3IDI2My41NzYgODYuMDU0N1oiIGZpbGw9IiNGRkU1MDAiIGZpbGwtcnVsZT0iZXZlbm9kZCIvPjwvZz48L3N2Zz4=) no-repeat 1rem/1.8rem, #b32121;
-    padding: 1rem 1rem 1rem 3.7rem;
-    color: white;
+    background: none;
+    padding: 1rem;
 }
 
-    .blazor-error-boundary::after {
-        content: "An error has occurred.";
+.blazor-error-boundary::after {
+    content: "An error has occurred.";
+}
+
+@media (max-width: 900px) {
+    .terminal-hero,
+    .game-grid {
+        grid-template-columns: 1fr;
     }
 
-.darker-border-checkbox.form-check-input {
-    border-color: #929292;
-}
-
-.form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
-    color: var(--muted);
-    text-align: end;
-}
-
-.form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
-    text-align: start;
+    .game-header {
+        flex-direction: column;
+        gap: 0.5rem;
+        align-items: flex-start;
+    }
 }


### PR DESCRIPTION
## Summary
- Restyled the home page with terminal-inspired hero, stat line, and supporting cards.
- Redesigned the game client layout into terminal panels for authentication and world output with command input controls.
- Rebuilt the shared CSS theme with a monochrome brutalist palette, terminal card styling, and responsive grids.

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925c6804a74833198ef8337c03ea2c5)