### PR TITLE
Add inventory command aliases for self examination

### DIFF
--- a/MooSharp.Tests/CommandHandlerTests.cs
+++ b/MooSharp.Tests/CommandHandlerTests.cs
@@ -266,6 +266,31 @@ public class CommandHandlerTests
     }
 
     [Fact]
+    public async Task InventoryHandler_ReturnsSelfExaminedEventWithInventory()
+    {
+        var player = CreatePlayer();
+
+        var item = new Object
+        {
+            Name = "Lantern",
+            Description = "An old lantern"
+        };
+
+        item.MoveTo(player);
+
+        var handler = new InventoryHandler();
+
+        var result = await handler.Handle(new InventoryCommand
+        {
+            Player = player
+        });
+
+        var message = Assert.Single(result.Messages);
+        var evt = Assert.IsType<SelfExaminedEvent>(message.Event);
+        Assert.Contains(item, evt.Inventory);
+    }
+
+    [Fact]
     public async Task ExamineHandler_ReturnsObjectDetailsWhenFound()
     {
         var room = CreateRoom("room");

--- a/MooSharp/Commands/Commands/InventoryCommand.cs
+++ b/MooSharp/Commands/Commands/InventoryCommand.cs
@@ -1,0 +1,34 @@
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class InventoryCommand : CommandBase<InventoryCommand>
+{
+    public required Player Player { get; init; }
+}
+
+public class InventoryCommandDefinition : ICommandDefinition
+{
+    public IReadOnlyCollection<string> Verbs { get; } = ["i", "inv", "inventory"];
+
+    public string Description => "Check what you're carrying.";
+
+    public ICommand Create(Player player, string args) =>
+        new InventoryCommand
+        {
+            Player = player
+        };
+}
+
+public class InventoryHandler : IHandler<InventoryCommand>
+{
+    public Task<CommandResult> Handle(InventoryCommand cmd, CancellationToken cancellationToken = default)
+    {
+        var result = new CommandResult();
+        var inventory = cmd.Player.Inventory.ToList();
+
+        result.Add(cmd.Player, new SelfExaminedEvent(cmd.Player, inventory));
+
+        return Task.FromResult(result);
+    }
+}


### PR DESCRIPTION
## Summary
- add an inventory command mapped to i/inv/inventory that emits SelfExaminedEvent for a player's items
- ensure inventory handler reuses existing self-examination formatting
- add coverage verifying the new inventory handler returns the expected event content

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b108e8ec83318ea07831380fc82b)