### PR TITLE
Add command to list online players

### DIFF
--- a/MooSharp.Tests/CommandHandlerTests.cs
+++ b/MooSharp.Tests/CommandHandlerTests.cs
@@ -345,6 +345,33 @@ public class CommandHandlerTests
         Assert.False(string.IsNullOrWhiteSpace(evt.Message));
     }
 
+    [Fact]
+    public async Task WhoHandler_ReturnsAlphabetizedOnlineUsernames()
+    {
+        var world = await CreateWorld();
+
+        var actor = CreatePlayer("Actor");
+        var observer = CreatePlayer("observer");
+        var zorro = CreatePlayer("Zorro");
+
+        world.Players["actor"] = actor;
+        world.Players["observer"] = observer;
+        world.Players["zorro"] = zorro;
+
+        var handler = new WhoHandler(world);
+
+        var result = await handler.Handle(new WhoCommand
+        {
+            Player = actor
+        });
+
+        var message = Assert.Single(result.Messages);
+        Assert.Equal(actor, message.Player);
+
+        var evt = Assert.IsType<OnlinePlayersEvent>(message.Event);
+        Assert.Equal(["Actor", "observer", "Zorro"], evt.Usernames);
+    }
+
     private static Task<World> CreateWorld(params Room[] rooms)
     {
         var store = new InMemoryWorldStore();

--- a/MooSharp/Commands/Commands/WhoCommand.cs
+++ b/MooSharp/Commands/Commands/WhoCommand.cs
@@ -1,0 +1,55 @@
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class WhoCommand : CommandBase<WhoCommand>
+{
+    public required Player Player { get; init; }
+}
+
+public class WhoCommandDefinition : ICommandDefinition
+{
+    public IReadOnlyCollection<string> Verbs { get; } = ["who"];
+
+    public string Description => "List all players currently online.";
+
+    public ICommand Create(Player player, string args) => new WhoCommand
+    {
+        Player = player
+    };
+}
+
+public class WhoHandler(World world) : IHandler<WhoCommand>
+{
+    public Task<CommandResult> Handle(WhoCommand cmd, CancellationToken cancellationToken = default)
+    {
+        var usernames = world.Players
+            .Values
+            .Select(player => player.Username)
+            .OrderBy(username => username, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        var result = new CommandResult();
+
+        result.Add(cmd.Player, new OnlinePlayersEvent(usernames));
+
+        return Task.FromResult(result);
+    }
+}
+
+public record OnlinePlayersEvent(IReadOnlyCollection<string> Usernames) : IGameEvent;
+
+public class OnlinePlayersEventFormatter : IGameEventFormatter<OnlinePlayersEvent>
+{
+    public string FormatForActor(OnlinePlayersEvent gameEvent)
+    {
+        if (gameEvent.Usernames.Count is 0)
+        {
+            return "No one is online.";
+        }
+
+        return $"Players online: {string.Join(", ", gameEvent.Usernames)}";
+    }
+
+    public string FormatForObserver(OnlinePlayersEvent gameEvent) => FormatForActor(gameEvent);
+}


### PR DESCRIPTION
## Summary
- add a who command that lists all connected player usernames and formats the output for display
- return online player information through a dedicated game event and presenter formatter
- cover the new handler with a unit test verifying alphabetical ordering

## Testing
- Not run (requires elevated permissions to execute dotnet test)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b1101d74833196080a68faf075c0)