### PR TITLE
Add read/write commands for object text

### DIFF
--- a/MooSharp.Tests/CommandHandlerTests.cs
+++ b/MooSharp.Tests/CommandHandlerTests.cs
@@ -321,6 +321,105 @@ public class CommandHandlerTests
     }
 
     [Fact]
+    public async Task WriteHandler_WritesOnRoomObjectAndBroadcasts()
+    {
+        var room = CreateRoom("room");
+        var world = await CreateWorld(room);
+
+        var writer = CreatePlayer("Writer");
+        var observer = CreatePlayer("Observer");
+        world.MovePlayer(writer, room);
+        world.MovePlayer(observer, room);
+
+        var item = new Object
+        {
+            Name = "Sign",
+            Description = "A wooden sign"
+        };
+
+        item.MoveTo(room);
+
+        var handler = new WriteHandler(world);
+
+        var result = await handler.Handle(new WriteCommand
+        {
+            Player = writer,
+            Target = "Sign",
+            Text = "welcome"
+        });
+
+        Assert.Equal("welcome", item.TextContent);
+
+        var actorMessage = Assert.Single(result.Messages, m => m.Player == writer);
+        Assert.IsType<ObjectWrittenOnEvent>(actorMessage.Event);
+
+        var observerMessage = Assert.Single(result.Messages, m => m.Player == observer);
+        Assert.Equal(MessageAudience.Observer, observerMessage.Audience);
+        Assert.IsType<ObjectWrittenOnEvent>(observerMessage.Event);
+    }
+
+    [Fact]
+    public async Task ReadHandler_ReturnsObjectReadEventWhenTextPresent()
+    {
+        var room = CreateRoom("room");
+        var world = await CreateWorld(room);
+
+        var player = CreatePlayer();
+        world.MovePlayer(player, room);
+
+        var item = new Object
+        {
+            Name = "Note",
+            Description = "A folded note"
+        };
+
+        item.WriteText("Meet me later");
+
+        item.MoveTo(room);
+
+        var handler = new ReadHandler(world);
+
+        var result = await handler.Handle(new ReadCommand
+        {
+            Player = player,
+            Target = "Note"
+        });
+
+        var message = Assert.Single(result.Messages);
+        var evt = Assert.IsType<ObjectReadEvent>(message.Event);
+        Assert.Same(item, evt.Item);
+    }
+
+    [Fact]
+    public async Task ReadHandler_ReturnsSystemMessageWhenNoText()
+    {
+        var room = CreateRoom("room");
+        var world = await CreateWorld(room);
+
+        var player = CreatePlayer();
+        world.MovePlayer(player, room);
+
+        var item = new Object
+        {
+            Name = "Note",
+            Description = "A folded note"
+        };
+
+        item.MoveTo(room);
+
+        var handler = new ReadHandler(world);
+
+        var result = await handler.Handle(new ReadCommand
+        {
+            Player = player,
+            Target = "Note"
+        });
+
+        var message = Assert.Single(result.Messages);
+        Assert.IsType<SystemMessageEvent>(message.Event);
+    }
+
+    [Fact]
     public async Task SayHandler_BroadcastsToRoom()
     {
         var room = CreateRoom("room");

--- a/MooSharp.Web/GameEngine.cs
+++ b/MooSharp.Web/GameEngine.cs
@@ -284,13 +284,18 @@ public class GameEngine(
         };
 
         foreach (var item in dto.Inventory)
-        {
-            var obj = new Object
             {
-                Id = new ObjectId(Guid.Parse(item.Id)),
-                Name = item.Name,
-                Description = item.Description
-            };
+                var obj = new Object
+                {
+                    Id = new ObjectId(Guid.Parse(item.Id)),
+                    Name = item.Name,
+                    Description = item.Description
+                };
+
+                if (!string.IsNullOrWhiteSpace(item.TextContent))
+                {
+                    obj.WriteText(item.TextContent);
+                }
 
             obj.MoveTo(player);
         }

--- a/MooSharp.Web/world.json
+++ b/MooSharp.Web/world.json
@@ -38,5 +38,11 @@
     }
   ],
   "Objects": [
+    {
+      "Name": "notice board",
+      "Description": "A wooden board for leaving notes.",
+      "RoomSlug": "atrium",
+      "TextContent": "Welcome to MooSharp!"
+    }
   ]
 }

--- a/MooSharp/Actors/Object.cs
+++ b/MooSharp/Actors/Object.cs
@@ -14,6 +14,7 @@ public class Object
     public required string Name { get; init; }
     public required string Description { get; init; }
     public IReadOnlyCollection<string> Keywords { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase).ToFrozenSet();
+    public string? TextContent { get; private set; }
 
     public IContainer? Container { get; private set; }
 
@@ -33,6 +34,13 @@ public class Object
 
         destination.AddToContents(this);
         Container = destination;
+    }
+
+    public void WriteText(string text)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+
+        TextContent = text.Trim();
     }
 
     public override string ToString() => Name;

--- a/MooSharp/Commands/AccessibleObjectSearcher.cs
+++ b/MooSharp/Commands/AccessibleObjectSearcher.cs
@@ -1,0 +1,20 @@
+namespace MooSharp;
+
+public static class AccessibleObjectSearcher
+{
+    public static SearchResult FindNearbyObject(Player player, Room room, string target)
+    {
+        ArgumentNullException.ThrowIfNull(player);
+        ArgumentNullException.ThrowIfNull(room);
+        ArgumentException.ThrowIfNullOrWhiteSpace(target);
+
+        var inventorySearch = player.Inventory.FindObjects(target);
+
+        if (inventorySearch.Status is not SearchStatus.NotFound)
+        {
+            return inventorySearch;
+        }
+
+        return room.FindObjects(target);
+    }
+}

--- a/MooSharp/Commands/Commands/ExamineCommand.cs
+++ b/MooSharp/Commands/Commands/ExamineCommand.cs
@@ -109,9 +109,25 @@ public record ObjectExaminedEvent(Object Item) : IGameEvent;
 
 public class ObjectExaminedEventFormatter : IGameEventFormatter<ObjectExaminedEvent>
 {
-    public string FormatForActor(ObjectExaminedEvent gameEvent) => gameEvent.Item.Description;
+    public string FormatForActor(ObjectExaminedEvent gameEvent)
+        => FormatDescription(gameEvent.Item);
 
-    public string FormatForObserver(ObjectExaminedEvent gameEvent) => gameEvent.Item.Description;
+    public string FormatForObserver(ObjectExaminedEvent gameEvent)
+        => FormatDescription(gameEvent.Item);
+
+    private static string FormatDescription(Object item)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine(item.Description);
+
+        if (!string.IsNullOrWhiteSpace(item.TextContent))
+        {
+            sb.AppendLine("There is something written on it.");
+        }
+
+        return sb.ToString().TrimEnd();
+    }
 }
 
 public record AmbiguousInputEvent(string Input, IReadOnlyCollection<Object> Candidates) : IGameEvent;

--- a/MooSharp/Commands/Commands/ReadCommand.cs
+++ b/MooSharp/Commands/Commands/ReadCommand.cs
@@ -1,0 +1,81 @@
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class ReadCommand : CommandBase<ReadCommand>
+{
+    public required Player Player { get; init; }
+    public required string Target { get; init; }
+}
+
+public class ReadCommandDefinition : ICommandDefinition
+{
+    public IReadOnlyCollection<string> Verbs { get; } = ["read"];
+
+    public string Description => "Read writing on an item. Usage: read <item>.";
+
+    public ICommand Create(Player player, string args) => new ReadCommand
+    {
+        Player = player,
+        Target = args
+    };
+}
+
+public class ReadHandler(World world) : IHandler<ReadCommand>
+{
+    public Task<CommandResult> Handle(ReadCommand cmd, CancellationToken cancellationToken = default)
+    {
+        var result = new CommandResult();
+        var target = cmd.Target.Trim();
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            result.Add(cmd.Player, new SystemMessageEvent("Read what?"));
+            return Task.FromResult(result);
+        }
+
+        var room = world.GetPlayerLocation(cmd.Player)
+            ?? throw new InvalidOperationException("Player has no known current location.");
+
+        var search = AccessibleObjectSearcher.FindNearbyObject(cmd.Player, room, target);
+
+        switch (search.Status)
+        {
+            case SearchStatus.NotFound:
+                result.Add(cmd.Player, new ItemNotFoundEvent(target));
+                break;
+
+            case SearchStatus.IndexOutOfRange:
+                result.Add(cmd.Player, new SystemMessageEvent($"You can't see a '{target}' here."));
+                break;
+
+            case SearchStatus.Ambiguous:
+                result.Add(cmd.Player, new AmbiguousInputEvent(target, search.Candidates));
+                break;
+
+            case SearchStatus.Found:
+                var item = search.Match!;
+
+                if (string.IsNullOrWhiteSpace(item.TextContent))
+                {
+                    result.Add(cmd.Player, new SystemMessageEvent($"There is nothing written on the {item.Name}."));
+                    break;
+                }
+
+                result.Add(cmd.Player, new ObjectReadEvent(item, item.TextContent));
+                break;
+        }
+
+        return Task.FromResult(result);
+    }
+}
+
+public record ObjectReadEvent(Object Item, string Content) : IGameEvent;
+
+public class ObjectReadEventFormatter : IGameEventFormatter<ObjectReadEvent>
+{
+    public string FormatForActor(ObjectReadEvent gameEvent)
+        => $"It reads: \"{gameEvent.Content}\"";
+
+    public string? FormatForObserver(ObjectReadEvent gameEvent) => null;
+}

--- a/MooSharp/Commands/Commands/WriteCommand.cs
+++ b/MooSharp/Commands/Commands/WriteCommand.cs
@@ -1,0 +1,110 @@
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class WriteCommand : CommandBase<WriteCommand>
+{
+    public required Player Player { get; init; }
+    public required string Target { get; init; }
+    public required string Text { get; init; }
+}
+
+public class WriteCommandDefinition : ICommandDefinition
+{
+    public IReadOnlyCollection<string> Verbs { get; } = ["write"];
+
+    public string Description => "Write a message on an item. Usage: write on <item> <text>.";
+
+    public ICommand Create(Player player, string args)
+    {
+        var trimmedArgs = args.Trim();
+
+        if (trimmedArgs.StartsWith("on ", StringComparison.OrdinalIgnoreCase))
+        {
+            trimmedArgs = trimmedArgs[3..];
+        }
+
+        var split = trimmedArgs
+            .Split(' ', 2, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        var target = split.ElementAtOrDefault(0) ?? string.Empty;
+        var text = split.ElementAtOrDefault(1) ?? string.Empty;
+
+        return new WriteCommand
+        {
+            Player = player,
+            Target = target,
+            Text = text
+        };
+    }
+}
+
+public class WriteHandler(World world) : IHandler<WriteCommand>
+{
+    public Task<CommandResult> Handle(WriteCommand cmd, CancellationToken cancellationToken = default)
+    {
+        var result = new CommandResult();
+
+        var target = cmd.Target.Trim();
+        var text = cmd.Text.Trim();
+
+        if (string.IsNullOrWhiteSpace(target))
+        {
+            result.Add(cmd.Player, new SystemMessageEvent("Write on what?"));
+            return Task.FromResult(result);
+        }
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            result.Add(cmd.Player, new SystemMessageEvent("Write what?"));
+            return Task.FromResult(result);
+        }
+
+        var room = world.GetPlayerLocation(cmd.Player)
+            ?? throw new InvalidOperationException("Player has no known current location.");
+
+        var search = AccessibleObjectSearcher.FindNearbyObject(cmd.Player, room, target);
+
+        switch (search.Status)
+        {
+            case SearchStatus.NotFound:
+                result.Add(cmd.Player, new ItemNotFoundEvent(target));
+                break;
+
+            case SearchStatus.IndexOutOfRange:
+                result.Add(cmd.Player, new SystemMessageEvent($"You can't see a '{target}' here."));
+                break;
+
+            case SearchStatus.Ambiguous:
+                result.Add(cmd.Player, new AmbiguousInputEvent(target, search.Candidates));
+                break;
+
+            case SearchStatus.Found:
+                var item = search.Match!;
+                item.WriteText(text);
+
+                var writeEvent = new ObjectWrittenOnEvent(cmd.Player, item, text);
+                result.Add(cmd.Player, writeEvent);
+
+                if (item.Location is Room location && ReferenceEquals(location, room))
+                {
+                    result.BroadcastToAllButPlayer(room, cmd.Player, writeEvent);
+                }
+
+                break;
+        }
+
+        return Task.FromResult(result);
+    }
+}
+
+public record ObjectWrittenOnEvent(Player Player, Object Item, string Text) : IGameEvent;
+
+public class ObjectWrittenOnEventFormatter : IGameEventFormatter<ObjectWrittenOnEvent>
+{
+    public string FormatForActor(ObjectWrittenOnEvent gameEvent)
+        => $"You write \"{gameEvent.Text}\" on the {gameEvent.Item.Name}.";
+
+    public string FormatForObserver(ObjectWrittenOnEvent gameEvent)
+        => $"{gameEvent.Player.Username} writes \"{gameEvent.Text}\" on the {gameEvent.Item.Name}.";
+}

--- a/MooSharp/Persistence/Dtos/InventoryItemDto.cs
+++ b/MooSharp/Persistence/Dtos/InventoryItemDto.cs
@@ -5,4 +5,5 @@ public class InventoryItemDto
     public required string Id { get; init; }
     public required string Name { get; init; }
     public required string Description { get; init; }
+    public string? TextContent { get; init; }
 }

--- a/MooSharp/Persistence/Dtos/ObjectDto.cs
+++ b/MooSharp/Persistence/Dtos/ObjectDto.cs
@@ -5,4 +5,5 @@ public class ObjectDto
     public required string Name { get; set; }
     public required string Description { get; set; }
     public string? RoomSlug { get; set; }
+    public string? TextContent { get; set; }
 }

--- a/MooSharp/World/WorldSeeder.cs
+++ b/MooSharp/World/WorldSeeder.cs
@@ -124,6 +124,11 @@ public class WorldSeeder(IOptions<AppOptions> options, ILogger<WorldSeeder> logg
                 Name = objectDto.Name
             };
 
+            if (!string.IsNullOrWhiteSpace(objectDto.TextContent))
+            {
+                obj.WriteText(objectDto.TextContent);
+            }
+
             obj.MoveTo(room);
         }
     }


### PR DESCRIPTION
## Summary
- add read and write commands so players can leave and view messages on objects, including examine hints
- persist object text content through DTOs, player inventory storage, and seeded world data

## Testing
- dotnet test MooSharp.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b3bad110833185e471f77198c465)