### PR TITLE
Refactor world clock for public testing

### DIFF
--- a/MooSharp.Tests/WorldClockServiceTests.cs
+++ b/MooSharp.Tests/WorldClockServiceTests.cs
@@ -1,0 +1,76 @@
+using NSubstitute;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using MooSharp.Messaging;
+using MooSharp.Persistence;
+
+namespace MooSharp.Tests;
+
+public class WorldClockServiceTests
+{
+    [Fact]
+    public async Task TriggerTickAsync_SendsMessagesToAllPlayers()
+    {
+        var world = CreateWorldWithPlayers(out var connections);
+        var presenter = Substitute.For<IGameMessagePresenter>();
+        presenter.Present(Arg.Any<GameMessage>()).Returns("event");
+
+        var clock = CreateWorldClock(world, presenter);
+
+        await clock.TriggerTickAsync(CancellationToken.None);
+
+        foreach (var connection in connections)
+        {
+            await connection.Received(1).SendMessageAsync(Arg.Any<string>());
+        }
+
+        presenter.Received(world.Players.Count).Present(Arg.Any<GameMessage>());
+    }
+
+    [Fact]
+    public async Task TriggerTickAsync_DoesNothingWhenNoPlayers()
+    {
+        var world = new World(Substitute.For<IWorldStore>(), NullLogger<World>.Instance);
+        var presenter = Substitute.For<IGameMessagePresenter>();
+
+        var clock = CreateWorldClock(world, presenter);
+
+        await clock.TriggerTickAsync(CancellationToken.None);
+
+        presenter.DidNotReceive().Present(Arg.Any<GameMessage>());
+    }
+
+    private static WorldClock CreateWorldClock(World world, IGameMessagePresenter presenter) => new(
+        world,
+        presenter,
+        Options.Create(new WorldClockOptions
+        {
+            TickIntervalSeconds = 1,
+            Events = ["event"]
+        }),
+        NullLogger<WorldClock>.Instance);
+
+    private static World CreateWorldWithPlayers(out List<IPlayerConnection> connections)
+    {
+        var world = new World(Substitute.For<IWorldStore>(), NullLogger<World>.Instance);
+        connections = [];
+
+        for (var i = 0; i < 2; i++)
+        {
+            var connection = Substitute.For<IPlayerConnection>();
+            connection.Id.Returns($"conn-{i}");
+            connection.SendMessageAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+
+            var player = new Player
+            {
+                Username = $"Player {i}",
+                Connection = connection
+            };
+
+            world.Players[connection.Id] = player;
+            connections.Add(connection);
+        }
+
+        return world;
+    }
+}

--- a/MooSharp.Web/ServiceCollectionExtensions.cs
+++ b/MooSharp.Web/ServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class ServiceCollectionExtensions
         services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IPlayerStore, SqlitePlayerStore>();
         services.AddSingleton<IWorldStore, SqliteWorldStore>();
+        services.AddSingleton<IWorldClock, WorldClock>();
     }
     
     public static void AddMooSharpMessaging(this IServiceCollection services, IConfiguration config)
@@ -37,6 +38,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddHostedService<GameEngine>();
         services.AddHostedService<AgentBackgroundService>();
+        services.AddHostedService<WorldClockService>();
     }
     
     public static void AddMooSharpOptions(this IServiceCollection services, IConfiguration config)
@@ -49,6 +51,11 @@ public static class ServiceCollectionExtensions
         services
             .AddOptionsWithValidateOnStart<AgentOptions>()
             .BindConfiguration(AgentOptions.SectionName)
+            .ValidateDataAnnotations();
+
+        services
+            .AddOptionsWithValidateOnStart<WorldClockOptions>()
+            .BindConfiguration(WorldClockOptions.SectionName)
             .ValidateDataAnnotations();
 
         services.Configure<ServiceProviderOptions>(s =>

--- a/MooSharp/Infrastructure/WorldClockOptions.cs
+++ b/MooSharp/Infrastructure/WorldClockOptions.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace MooSharp;
+
+public class WorldClockOptions
+{
+    public const string SectionName = "WorldClock";
+
+    [Range(1, int.MaxValue)]
+    public int TickIntervalSeconds { get; init; } = 60;
+
+    [MinLength(1)]
+    public List<string> Events { get; init; } =
+    [
+        "The sun begins to set.",
+        "It starts to rain."
+    ];
+}

--- a/MooSharp/MooSharp.csproj
+++ b/MooSharp/MooSharp.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
       <PackageReference Include="Dapper" Version="2.1.35" />
       <PackageReference Include="Handlebars.Net" Version="2.1.5" />
+      <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.11" />
       <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.11" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.11" />

--- a/MooSharp/World/IWorldClock.cs
+++ b/MooSharp/World/IWorldClock.cs
@@ -1,0 +1,6 @@
+namespace MooSharp;
+
+public interface IWorldClock
+{
+    Task TriggerTickAsync(CancellationToken cancellationToken);
+}

--- a/MooSharp/World/WorldClock.cs
+++ b/MooSharp/World/WorldClock.cs
@@ -1,0 +1,62 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MooSharp.Messaging;
+
+namespace MooSharp;
+
+public class WorldClock(
+    World world,
+    IGameMessagePresenter presenter,
+    IOptions<WorldClockOptions> options,
+    ILogger<WorldClock> logger) : IWorldClock
+{
+    public async Task TriggerTickAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (world.Players.IsEmpty)
+        {
+            return;
+        }
+
+        var eventText = GetEventText();
+
+        if (string.IsNullOrWhiteSpace(eventText))
+        {
+            logger.LogWarning("World clock produced an empty event; skipping broadcast");
+            return;
+        }
+
+        var gameEvent = new SystemMessageEvent(eventText);
+
+        var sends = world.Players
+            .Values
+            .Select(player => new GameMessage(player, gameEvent))
+            .Select(message => (message.Player, Content: presenter.Present(message)))
+            .Where(result => !string.IsNullOrWhiteSpace(result.Content))
+            .Select(result => result.Player.Connection.SendMessageAsync(result.Content!));
+
+        try
+        {
+            await Task.WhenAll(sends);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error broadcasting world clock event");
+        }
+    }
+
+    private string GetEventText()
+    {
+        var events = options.Value.Events;
+
+        if (events.Count == 0)
+        {
+            return string.Empty;
+        }
+
+        var index = Random.Shared.Next(events.Count);
+
+        return events[index];
+    }
+}

--- a/MooSharp/World/WorldClockService.cs
+++ b/MooSharp/World/WorldClockService.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace MooSharp;
+
+public class WorldClockService(
+    IWorldClock worldClock,
+    IOptions<WorldClockOptions> options,
+    TimeProvider timeProvider) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var interval = TimeSpan.FromSeconds(options.Value.TickIntervalSeconds);
+
+        using var timer = new PeriodicTimer(interval, timeProvider);
+
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            await worldClock.TriggerTickAsync(stoppingToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract the world clock tick behavior into a public IWorldClock implementation instead of relying on InternalsVisibleTo
- update the hosted service to depend on the world clock abstraction and register it for dependency injection
- adjust the world clock tests to exercise the new component

## Testing
- sudo env "PATH=$PATH" dotnet test MooSharp.sln

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928b0ba8b908331ad2c31c51eca7b6e)